### PR TITLE
build.c: use inserts to populate index on creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(BUILD_WITH_USEARCH "Build with usearch as hnsw provider" ON)
 option(BUILD_LIBHNSW "Build libhnsw as hnsw provider" OFF)
 option(CODECOVERAGE "Enable code coverage for the build" OFF)
 option(BENCH "Enable benchmarking" OFF)
+option(BUILD_VIA_INSERTS "Use inserts to populate hnsw index when created on a table with existing rows" OFF)
 
 if(CODECOVERAGE)
   message(STATUS "Code coverage is enabled.")
@@ -41,6 +42,11 @@ endif(CODECOVERAGE)
 if (BENCH)
   message(STATUS "Benchmarking is enabled.")
   add_compile_definitions(LANTERN_BENCH)
+endif()
+
+if (BUILD_VIA_INSERTS)
+  message(STATUS "Build via Inserts is enabled.")
+  add_compile_definitions(BUILD_VIA_INSERTS)
 endif()
 
 # options passed into lanterndb sourcecode


### PR DESCRIPTION
Add a feature-toggled way to have build.c populate hnsw index using insert logic.

The reason for this is two folds:
- Unify build and insertion logic
- Upcoming migration away from blockmap, and the current build logic's incompatibility with it

Note that the change here for build.c only applies to the case when an index is created on a table that already has rows.

In particular, externally created index getting uploaded to postgres will not cause the new logic to get exercised.

Feature is disabled by default for now as we haven't benchmarked this new approach, and think it'll
impact the performance of index creation.