### PR TITLE
Fix package build regression. Make sure built packages are portible

### DIFF
--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -62,7 +62,7 @@ function build_and_install() {
    # TODO:: remove after test
   flags="-DUSEARCH_NO_MARCH_NATIVE=ON"
   # Treat warnings as errors in CI/CD
-  flags+="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+  flags+=" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
   # if [[ $ARCH == *"arm"* ]]; then
   #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
   # fi


### PR DESCRIPTION
Because of bad concatination, two cmake flags were right after each other, with no space in between, which means in ci/cd both were ignored, causing released packages to carry out non-portible cpu-native builds