### PR TITLE
Check for undefined symbols #145

### DIFF
--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -37,7 +37,12 @@ function package_if_necessary() {
 }
 
 function cleanup_environment() {
+  # Check for undefined symbols
+  if [ ! -n "$ENABLE_COVERAGE" ]
+  then
+    /tmp/lantern/scripts/check_symbols.sh ./lantern.so
+  fi
+
   # Chown to postgres for running tests
   chown -R postgres:postgres /tmp/lantern
 }
-

--- a/scripts/check_symbols.sh
+++ b/scripts/check_symbols.sh
@@ -6,7 +6,7 @@ SCRIPT=$(realpath "$0")
 THIS_DIR=$(dirname "$SCRIPT")
 
 # get all the symbols our shared library assumes are externally provided
-MAYBE_EXTERN=$(nm -u $1 | awk '{print $2}' | sed  -e 's/@/@@/')
+MAYBE_EXTERN=$(nm -D $1 | grep ' U ' | awk '{print $2}' | sed -e 's/@.*//')
 
 # get all the symbols that are externally provided
 EXTERN_PROVIDED=$($THIS_DIR/extern_defined.sh)


### PR DESCRIPTION
I have modified `scripts/extern_defined.sh` script to get the postgres binary dependencies dynamic and also get postgres binary path from `pgconfig`.  
Now there will be check in CI for undefined symbols in our binary.

For test I have added undefined function in our hnsw.h header file and the called that function from hnsw.c file. The check is returning the missing symbol correctly
<img width="918" alt="Pasted Graphic" src="https://github.com/lanterndata/lantern/assets/17221195/0e31cf2a-2269-49be-940b-c66933c6c982">

closes #145 
