### PR TITLE
remove pgvector specific l2sq metric

### DIFF
--- a/ci/scripts/run-benchmarks.sh
+++ b/ci/scripts/run-benchmarks.sh
@@ -30,7 +30,7 @@ POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres 1>/
 wait_for_pg
 cd $WORKDIR/build
 
-export DATABASE_URL=postgresql://localhost:5432/postgres
+export LANTERN_DATABASE_URL=postgresql://localhost:5432/postgres
 git clone https://github.com/lanterndata/benchmark
 cd benchmark
 pip install -r core/requirements.txt

--- a/ci/scripts/run-benchmarks.sh
+++ b/ci/scripts/run-benchmarks.sh
@@ -15,7 +15,7 @@ wait_for_pg(){
  done
 }
 
-export WORKDIR=/tmp/lantern
+export WORKDIR=/home/vagrant/lanterndb
 export PG_VERSION=15
 export GITHUB_OUTPUT=/dev/null
 export PGDATA=/etc/postgresql/$PG_VERSION/main/
@@ -31,6 +31,7 @@ wait_for_pg
 cd $WORKDIR/build
 
 export LANTERN_DATABASE_URL=postgresql://localhost:5432/postgres
+export DATABASE_URL=postgresql://localhost:5432/postgres
 git clone https://github.com/lanterndata/benchmark
 cd benchmark
 pip install -r core/requirements.txt

--- a/ci/scripts/run-benchmarks.sh
+++ b/ci/scripts/run-benchmarks.sh
@@ -15,7 +15,7 @@ wait_for_pg(){
  done
 }
 
-export WORKDIR=/home/vagrant/lanterndb
+export WORKDIR=/tmp/lantern
 export PG_VERSION=15
 export GITHUB_OUTPUT=/dev/null
 export PGDATA=/etc/postgresql/$PG_VERSION/main/

--- a/sql/lantern.sql
+++ b/sql/lantern.sql
@@ -29,14 +29,13 @@ BEGIN
 	END IF;
 
 	IF pgvector_exists THEN
-		-- taken from pgvector so our index can work with pgvector types
-		CREATE FUNCTION vector_l2sq_dist(vector, vector) RETURNS float8
-			AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+                CREATE FUNCTION l2sq_dist(real[], real[]) RETURNS real
+                        AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 		CREATE OPERATOR CLASS dist_vec_l2sq_ops
 			DEFAULT FOR TYPE vector USING lantern_hnsw AS
 			OPERATOR 1 <-> (vector, vector) FOR ORDER BY float_ops,
-			FUNCTION 1 vector_l2sq_dist(vector, vector);
+			FUNCTION 1 l2sq_dist(real[], real[]);
 	END IF;
 
 
@@ -46,16 +45,6 @@ BEGIN
 		-- create access method
 		CREATE ACCESS METHOD hnsw TYPE INDEX HANDLER hnsw_handler;
 		COMMENT ON ACCESS METHOD hnsw IS 'LanternDB access method for vector embeddings, based on the hnsw algorithm';
-		IF pgvector_exists THEN
-			-- An older version of pgvector exists, which does not have hnsw yet
-			-- So, there is no naming conflict. We still add a compatibility operator class
-			-- so pgvector vector type can be used with our index
-			-- taken from pgvector so our index can work with pgvector types
-			CREATE OPERATOR CLASS dist_vec_l2sq_ops
-				DEFAULT FOR TYPE vector USING hnsw AS
-				OPERATOR 1 <-> (vector, vector) FOR ORDER BY float_ops,
-				FUNCTION 1 vector_l2sq_dist(vector, vector);
-		END IF;
 	END IF;
 END;
 $BODY$
@@ -68,7 +57,7 @@ CREATE FUNCTION ldb_generic_dist(real[], real[]) RETURNS real
 CREATE FUNCTION ldb_generic_dist(integer[], integer[]) RETURNS real
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 	
-CREATE FUNCTION l2sq_dist(real[], real[]) RETURNS real
+CREATE OR REPLACE FUNCTION l2sq_dist(real[], real[]) RETURNS real
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION cos_dist(real[], real[]) RETURNS real

--- a/sql/lantern.sql
+++ b/sql/lantern.sql
@@ -1,3 +1,19 @@
+-- functions
+CREATE FUNCTION ldb_generic_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION ldb_generic_dist(integer[], integer[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION l2sq_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cos_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION hamming_dist(integer[], integer[]) RETURNS integer
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 -- Definitions concerning our hnsw-based index data strucuture
 
 CREATE FUNCTION hnsw_handler(internal) RETURNS index_am_handler
@@ -29,9 +45,7 @@ BEGIN
 	END IF;
 
 	IF pgvector_exists THEN
-                CREATE FUNCTION l2sq_dist(real[], real[]) RETURNS real
-                        AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
+                -- Define operator class for vector type
 		CREATE OPERATOR CLASS dist_vec_l2sq_ops
 			DEFAULT FOR TYPE vector USING lantern_hnsw AS
 			OPERATOR 1 <-> (vector, vector) FOR ORDER BY float_ops,
@@ -49,22 +63,6 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql;
-
--- functions
-CREATE FUNCTION ldb_generic_dist(real[], real[]) RETURNS real
-	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-	
-CREATE FUNCTION ldb_generic_dist(integer[], integer[]) RETURNS real
-	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-	
-CREATE OR REPLACE FUNCTION l2sq_dist(real[], real[]) RETURNS real
-	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION cos_dist(real[], real[]) RETURNS real
-	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION hamming_dist(integer[], integer[]) RETURNS integer
-	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- operators
 CREATE OPERATOR <-> (

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -296,15 +296,6 @@ static float4 array_dist(ArrayType *a, ArrayType *b, usearch_metric_kind_t metri
     return usearch_dist(ax, bx, metric_kind, a_dim, usearch_scalar_f32_k);
 }
 
-static float8 vector_dist(Vector *a, Vector *b, usearch_metric_kind_t metric_kind)
-{
-    if(a->dim != b->dim) {
-        elog(ERROR, "expected equally sized vectors but got vectors with dimensions %d and %d", a->dim, b->dim);
-    }
-
-    return usearch_dist(a->x, b->x, metric_kind, a->dim, usearch_scalar_f32_k);
-}
-
 PGDLLEXPORT PG_FUNCTION_INFO_V1(ldb_generic_dist);
 Datum       ldb_generic_dist(PG_FUNCTION_ARGS) { PG_RETURN_NULL(); }
 

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -332,15 +332,6 @@ Datum       hamming_dist(PG_FUNCTION_ARGS)
     PG_RETURN_INT32(array_dist(a, b, usearch_metric_hamming_k));
 }
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_l2sq_dist);
-Datum       vector_l2sq_dist(PG_FUNCTION_ARGS)
-{
-    Vector *a = PG_GETARG_VECTOR_P(0);
-    Vector *b = PG_GETARG_VECTOR_P(1);
-
-    PG_RETURN_FLOAT8((double)vector_dist(a, b, usearch_metric_l2sq_k));
-}
-
 /*
  * Get data type of index
  */

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -28,7 +28,6 @@ PGDLLEXPORT void _PG_init(void);
 PGDLLEXPORT void _PG_fini(void);
 
 PGDLLEXPORT Datum l2sq_dist(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum vector_l2sq_dist(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum hamming_dist(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum cos_dist(PG_FUNCTION_ARGS);
 

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -82,7 +82,7 @@ usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index)
     void          *fnaddr = fninfo->fn_addr;
     ReleaseCatCacheList(proclist);
 
-    if(fnaddr == l2sq_dist || fnaddr == vector_l2sq_dist) {
+    if(fnaddr == l2sq_dist) {
         return usearch_metric_l2sq_k;
     } else if(fnaddr == hamming_dist) {
         return usearch_metric_hamming_k;

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -89,34 +89,12 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
  100 | 2.00
 (7 rows)
 
-EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN (COSTS FALSE) SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Limit  (cost=0.00..7.17 rows=7 width=56)
-   ->  Index Scan using small_world_v_idx on small_world  (cost=0.00..8.20 rows=8 width=56)
-         Order By: (v <-> '[0,1,0]'::vector)
-(3 rows)
-
-SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
- id  | dist 
------+------
- 010 | 0.00
- 011 | 1.00
- 000 | 1.00
- 110 | 1.00
- 001 | 2.00
- 111 | 2.00
- 100 | 2.00
-(7 rows)
-
-EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Limit  (cost=0.00..7.17 rows=7 width=56)
-   ->  Index Scan using small_world_v_idx on small_world  (cost=0.00..8.20 rows=8 width=56)
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Limit
+   ->  Index Scan using small_world_v_idx on small_world
          Order By: (v <-> '[0,1,0]'::vector)
 (3 rows)
 

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -98,7 +98,7 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
          Order By: (v <-> '[0,1,0]'::vector)
 (3 rows)
 
-SELECT id, ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
  id  | dist 
 -----+------
@@ -111,12 +111,12 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
  100 | 2.00
 (7 rows)
 
-EXPLAIN SELECT id, ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Limit  (cost=0.00..7.15 rows=7 width=56)
-   ->  Index Scan using small_world_v_idx on small_world  (cost=0.00..8.18 rows=8 width=56)
+ Limit  (cost=0.00..7.17 rows=7 width=56)
+   ->  Index Scan using small_world_v_idx on small_world  (cost=0.00..8.20 rows=8 width=56)
          Order By: (v <-> '[0,1,0]'::vector)
 (3 rows)
 
@@ -193,5 +193,5 @@ ERROR:  Operator <-> has no standalone meaning and is reserved for use in vector
 -- Expect error due to mismatching vector dimensions
 SELECT 1 FROM small_world ORDER BY v <-> '[0,1,0,1]' LIMIT 1;
 ERROR:  Expected vector with dimension 3, got 4
-SELECT vector_l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
-ERROR:  expected equally sized vectors but got vectors with dimensions 2 and 3
+SELECT l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
+ERROR:  expected equally sized arrays but got arrays with dimensions 2 and 3

--- a/test/sql/hnsw_vector.sql
+++ b/test/sql/hnsw_vector.sql
@@ -39,9 +39,9 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
-SELECT id, ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-EXPLAIN SELECT id, ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
 -- Verify that index creation on a large vector produces an error
@@ -79,4 +79,4 @@ SELECT ARRAY[1,2,3] <-> ARRAY[3,2,1];
 
 -- Expect error due to mismatching vector dimensions
 SELECT 1 FROM small_world ORDER BY v <-> '[0,1,0,1]' LIMIT 1;
-SELECT vector_l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
+SELECT l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);

--- a/test/sql/hnsw_vector.sql
+++ b/test/sql/hnsw_vector.sql
@@ -36,12 +36,7 @@ INSERT INTO small_world (v) VALUES (NULL);
 -- Distance functions
 SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-
-SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-EXPLAIN SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN (COSTS FALSE) SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
 -- Verify that index creation on a large vector produces an error


### PR DESCRIPTION
This removes the extra function to calculate L2 squared distance specifically on pgvectors vector type, addressing #92. It also cleans up what I believe is a superflous condition in the sql file. In case it's useful, [this](https://github.com/pgvector/pgvector/blob/b247b688a8ef56103b2dea1f9dd53a87b27696b6/sql/vector.sql#L145-L146) is where pgvector defines the implicit cast of their datatype to real