### PR TITLE
Set module extension to dylib for mac and postgres 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,15 @@ set(USEARCH_BUILD_TEST OFF)
 set(USEARCH_BUILD_BENCHMARK OFF)
 add_subdirectory("./third_party/usearch/c")
 
+string(REGEX MATCH "^PostgreSQL (\[0-9]+).*"
+  PostgreSQL_VERSION_NUMBER ${PostgreSQL_VERSION_STRING})
+set(PG_VERSION ${CMAKE_MATCH_1})
+
+# For Apple and Postgres 16 use .dylib instead of .so
+if (APPLE AND PG_VERSION VERSION_GREATER_EQUAL "16")
+  set(CMAKE_SHARED_MODULE_SUFFIX ".dylib")
+endif()
+
 # ADD LanternDB! Let there be light!
 add_library(lantern MODULE ${SOURCES})
 
@@ -246,12 +255,9 @@ if (CLANG_FORMAT)
 endif()
 
 # Package universal install script
-string(REGEX MATCH "^PostgreSQL (\[0-9]+).*"
-  PostgreSQL_VERSION_NUMBER ${PostgreSQL_VERSION_STRING})
-
 add_custom_target(
   archive
-  ${CMAKE_COMMAND} -E env SOURCE_DIR=${CMAKE_SOURCE_DIR} BUILD_DIR=${CMAKE_BINARY_DIR} PG_VERSION=${CMAKE_MATCH_1} ${CMAKE_SOURCE_DIR}/scripts/package.sh
+  ${CMAKE_COMMAND} -E env SOURCE_DIR=${CMAKE_SOURCE_DIR} BUILD_DIR=${CMAKE_BINARY_DIR} PG_VERSION=${PG_VERSION} ${CMAKE_SOURCE_DIR}/scripts/package.sh
   DEPENDS ${CMAKE_BINARY_DIR}/${_script_file}
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
@@ -259,6 +265,7 @@ add_dependencies(archive lantern)
 
 # Debian packaging
 set(CPACK_GENERATOR "DEB")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "postgresql-${CMAKE_MATCH_1}, postgresql-${CMAKE_MATCH_1}-pgvector")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "postgresql-${PG_VERSION}, postgresql-${PG_VERSION}-pgvector")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Lantern Data")
 include(CPack)
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 💡 Lantern
 
-[![build](https://github.com/lanterndata/lantern/actions/workflows/build-linux.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/build-linux.yaml)
-[![test](https://github.com/lanterndata/lantern/actions/workflows/test-linux.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/test-linux.yaml)
+[![build](https://github.com/lanterndata/lantern/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/build.yaml)
+[![test](https://github.com/lanterndata/lantern/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/github/lanterndata/lanterndb/branch/main/graph/badge.svg)](https://codecov.io/github/lanterndata/lanterndb)
 [![Run on Replit](https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit)](https://replit.com/@lanterndata/lantern-playground#.replit)
 

--- a/ci/scripts/universal-package.sh
+++ b/ci/scripts/universal-package.sh
@@ -33,7 +33,7 @@ for f in $(find "." -name "*.tar"); do
     fi
 
     mkdir -p $current_dest_folder
-    cp $current_archive_name/src/*.so $current_dest_folder/
+    cp $current_archive_name/src/*.{so,dylib} $current_dest_folder/ 2>/dev/null || true
 done
 
 if [ ! -z "$PACKAGE_EXTRAS" ]

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -7,7 +7,11 @@ PACKAGE_NAME=lantern-${EXT_VERSION}-postgres-${PG_VERSION}-${PLATFORM}-${ARCH}
 
 mkdir -p ${BUILD_DIR}/${PACKAGE_NAME}/src
 cp ${SOURCE_DIR}/scripts/packaging/* ${BUILD_DIR}/${PACKAGE_NAME}/
-cp ${BUILD_DIR}/*.so ${BUILD_DIR}/${PACKAGE_NAME}/src
+
+# For Mac OS and Postgres 16 the module will have .dylib extension
+# Instead of .so, so any of the files may not exist
+# So we will ignore the error from cp command
+cp ${BUILD_DIR}/*.{so,dylib} ${BUILD_DIR}/${PACKAGE_NAME}/src 2>/dev/null || true
 cp ${BUILD_DIR}/*.sql ${BUILD_DIR}/${PACKAGE_NAME}/src
 
 for f in $(find "${SOURCE_DIR}/sql/updates/" -name "*.sql"); do

--- a/scripts/packaging/install.sh
+++ b/scripts/packaging/install.sh
@@ -54,7 +54,7 @@ then
   exit
 fi
 
-cp -r src/${ARCH}/${PLATFORM}/${PG_VERSION}/*.so $PG_LIBRARY_DIR
+cp -r src/${ARCH}/${PLATFORM}/${PG_VERSION}/*.{so,dylib} $PG_LIBRARY_DIR 2>/dev/null || true
 cp -r shared/*.sql $PG_EXTENSION_DIR
 cp -r shared/*.control $PG_EXTENSION_DIR
 


### PR DESCRIPTION
In Postgres 16 the file extension for shared libraries of extension is changed from `.so` to `.dylib`, I have added a check in Cmake to apply corresponding file extension based on Postgres version and Platform. Also did necessary changes in packaging scripts.
closes #164 