### PR TITLE
replace vector_l2sq_dist with overloaded l2sq_dist

### DIFF
--- a/sql/updates/0.0.4-latest.sql
+++ b/sql/updates/0.0.4-latest.sql
@@ -1,0 +1,17 @@
+-- drop the old implementation
+DROP FUNCTION IF EXISTS vector_l2sq_dist(vector, vector);
+
+-- replace is with overloaded version
+BEGIN
+	-- Check if the vector type from pgvector exists
+	SELECT EXISTS (
+		SELECT 1
+		FROM pg_type
+		WHERE typname = 'vector'
+	) INTO pgvector_exists;
+
+	IF pgvector_exists THEN
+                CREATE FUNCTION l2sq_dist(vector, vector) RETURNS float8
+                        AS 'MODULE_PATHNAME', 'vector_l2sq_dist' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+        END IF
+END

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -98,7 +98,7 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
          Order By: (v <-> '[0,1,0]'::vector)
 (3 rows)
 
-SELECT ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+SELECT ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
  dist 
 ------
@@ -111,7 +111,7 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
  2.00
 (7 rows)
 
-EXPLAIN (COSTS FALSE) SELECT ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
                        QUERY PLAN                        
 ---------------------------------------------------------
@@ -171,5 +171,5 @@ ERROR:  Operator <-> has no standalone meaning and is reserved for use in vector
 -- Expect error due to mismatching vector dimensions
 SELECT 1 FROM small_world ORDER BY v <-> '[0,1,0,1]' LIMIT 1;
 ERROR:  Expected vector with dimension 3, got 4
-SELECT vector_l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
+SELECT l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
 ERROR:  expected equally sized vectors but got vectors with dimensions 2 and 3

--- a/test/sql/hnsw_vector.sql
+++ b/test/sql/hnsw_vector.sql
@@ -39,9 +39,9 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
-SELECT ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+SELECT ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-EXPLAIN (COSTS FALSE) SELECT ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
 -- Verify that index creation on a large vector produces an error
@@ -77,4 +77,4 @@ SELECT ARRAY[1,2,3] <-> ARRAY[3,2,1];
 
 -- Expect error due to mismatching vector dimensions
 SELECT 1 FROM small_world ORDER BY v <-> '[0,1,0,1]' LIMIT 1;
-SELECT vector_l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
+SELECT l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);


### PR DESCRIPTION
This should more cleanly address #92. Instead of removing vector_l2sq_dist, it overloads the l2sq_dist function for vector types if pgvector is present. I also added an update file