### PR TITLE
Create source code archive manually

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,8 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
       - uses: actions/download-artifact@v3
         with:
           name: lantern-package
@@ -66,6 +68,11 @@ jobs:
         with:
           name: ${{ steps.package.outputs.package_name }}
           path: ${{ steps.package.outputs.package_path }}
+      - name: Create source code archive with submodules
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.create_release }}
+        run: |
+          find ./ -name '.git*' -exec rm -rv {} \; || true
+          tar -czf /tmp/lantern-v${{ steps.package.outputs.package_version }}-source.tar.gz .
       - uses: geekyeggo/delete-artifact@v2
         with:
           name: lantern-package
@@ -76,5 +83,7 @@ jobs:
         with:
           name: LanternDB v${{ steps.package.outputs.package_version }}
           tag_name: v${{ steps.package.outputs.package_version }}
-          files: ${{ steps.package.outputs.package_path }}
+          files: |
+            ${{ steps.package.outputs.package_path }}
+            /tmp/lantern-v${{ steps.package.outputs.package_version }}-source.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
Currently on release pipeline the Source Code archive Github is creating automatically does not include the submodules in it, so basically if someone will download the source code archive and try to build from it one will get an error.
With this PR, we will create an archive of source code with all submodules manually and upload it to release artifacts under the name `lantern-v$version-source.tar.gz`