### PR TITLE
Ability to specify pg_config from env variables

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -48,10 +48,14 @@
 # Define additional search paths for root directories.
 set(PostgreSQL_ROOT_DIRECTORIES ENV PGROOT ENV PGPATH ${PostgreSQL_ROOT})
 
-find_program(
-  PG_CONFIG pg_config
-  PATHS ${PostgreSQL_ROOT_DIRECTORIES}
-  PATH_SUFFIXES bin)
+if (DEFINED ENV{PG_CONFIG})
+  set(PG_CONFIG "$ENV{PG_CONFIG}")
+else()
+  find_program(
+    PG_CONFIG pg_config
+    PATHS ${PostgreSQL_ROOT_DIRECTORIES}
+    PATH_SUFFIXES bin)
+endif()
 
 if(NOT PG_CONFIG)
   message(FATAL_ERROR "Could not find pg_config")


### PR DESCRIPTION
This change will help us to specify the pg_config from env variable `PG_CONFIG`.
This is needed for homebrew formula, so we will make sure that we are compiling against the same version that we have found in homebrew.
