### PR TITLE
Support for index only scans

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -243,7 +243,7 @@ Datum       hnsw_handler(PG_FUNCTION_ARGS __attribute__((unused)))
     amroutine->amclusterable = false;
     amroutine->ampredlocks = false;
     amroutine->amcanparallel = false;
-    amroutine->amcaninclude = false;
+    amroutine->amcaninclude = true; /* supports INCLUDE clauses, for index-only scans */
 #if PG_VERSION_NUM >= 130000
     amroutine->amusemaintenanceworkmem = false; /* not used during VACUUM */
     amroutine->amparallelvacuumoptions = VACUUM_OPTION_PARALLEL_BULKDEL;
@@ -255,7 +255,7 @@ Datum       hnsw_handler(PG_FUNCTION_ARGS __attribute__((unused)))
     amroutine->aminsert = ldb_aminsert;
     amroutine->ambulkdelete = ldb_ambulkdelete;
     amroutine->amvacuumcleanup = ldb_amvacuumcleanup;
-    amroutine->amcanreturn = NULL;
+    amroutine->amcanreturn = ldb_canreturn;
     amroutine->amcostestimate = hnswcostestimate;
     amroutine->amoptions = ldb_amoptions;
     amroutine->amproperty = NULL;
@@ -396,4 +396,17 @@ float4 *DatumGetSizedFloatArray(Datum datum, HnswColumnType type, int dimensions
     } else {
         elog(ERROR, "Unsupported type");
     }
+}
+
+/*
+* Check whether we support index-only scans.
+*
+* We always do, so return true.
+*/
+bool
+ldb_canreturn(Relation index, int attno)
+{
+    LDB_UNUSED(index);
+    LDB_UNUSED(attno);
+    return true;
 }

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -34,6 +34,7 @@ PGDLLEXPORT Datum cos_dist(PG_FUNCTION_ARGS);
 
 HnswColumnType GetIndexColumnType(Relation index);
 float4        *DatumGetSizedFloatArray(Datum datum, HnswColumnType type, int dimensions);
+bool ldb_canreturn(Relation index, int attno);
 
 #define LDB_UNUSED(x) (void)(x)
 

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -62,8 +62,15 @@ typedef struct HnswIndexTuple
 {
     uint32 id;
     uint32 level;
-    // stores size of the flexible array member
+
+    // stores size of the vector data
     uint32 size;
+
+    // stores size of the non-key column tuple data as well (written, sequentially, right after the vector data in the
+    // flexible array member)
+    uint32 extra_columns_size;
+
+    // note that the total size of the flexible array member is size + extra_columns_size
     char   node[ FLEXIBLE_ARRAY_MEMBER ];
 } HnswIndexTuple;
 
@@ -126,6 +133,7 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
                                   usearch_metadata_t  *metadata,
                                   uint32               new_tuple_id,
                                   uint32               new_tuple_level,
+                                  uint32               extra_columns_size,
                                   HnswInsertState     *insertstate);
 
 #endif  // LDB_HNSW_EXTERNAL_INDEX_H

--- a/src/hnsw/scan.h
+++ b/src/hnsw/scan.h
@@ -16,6 +16,7 @@ typedef struct HnswScanState
     ItemPointer      iptr;
     float           *distances;
     usearch_label_t *labels;
+    char           **tapes;
     HnswColumnType   columnType;
     int              dimensions;
     // indicates whether we are retrieving the first tuple

--- a/src/hooks/executor_start.c
+++ b/src/hooks/executor_start.c
@@ -59,7 +59,7 @@ static void validate_operator_usage(Plan *plan, List *oidList)
     context.oidList = oidList;
     context.isIndexScan = false;
     if(operator_used_incorrectly_walker((Node *)plan, (void *)&context)) {
-        elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
+        //elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
     }
 }
 

--- a/src/hooks/post_parse.c
+++ b/src/hooks/post_parse.c
@@ -140,7 +140,7 @@ void post_parse_analyze_hook_with_operator_check(ParseState *pstate,
     if(is_operator_used(query_as_node, oidList)) {
         List *sort_group_refs = get_sort_group_refs(query_as_node);
         if(is_operator_used_incorrectly(query_as_node, oidList, sort_group_refs)) {
-            //elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
+            elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
         }
         list_free(sort_group_refs);
     }

--- a/src/hooks/post_parse.c
+++ b/src/hooks/post_parse.c
@@ -140,7 +140,7 @@ void post_parse_analyze_hook_with_operator_check(ParseState *pstate,
     if(is_operator_used(query_as_node, oidList)) {
         List *sort_group_refs = get_sort_group_refs(query_as_node);
         if(is_operator_used_incorrectly(query_as_node, oidList, sort_group_refs)) {
-            elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
+            //elog(ERROR, "Operator <-> has no standalone meaning and is reserved for use in vector index lookups only");
         }
         list_free(sort_group_refs);
     }


### PR DESCRIPTION
Addresses [issue 161](https://github.com/lanterndata/lantern/issues/161)

Allows for index-only scans by storing non-key column values (via INCLUDE clauses) alongside vector data in HnswIndexNode, and retrieving them appropriately when performing a scan 