### PR TITLE
Add support for unlogged tables (#125)

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -438,15 +438,16 @@ static void BuildIndex(
         BlockNumber numBlocks;
 
         // Populate numBlocks correctly by explicitly handling each possible value forkNum can take
-        switch (forkNum) {
+        switch(forkNum) {
             case MAIN_FORKNUM:
                 numBlocks = RelationGetNumberOfBlocks(heap);
                 break;
-            default: // should be case INIT_FORKNUM, but set to default to keep compiler quiet
+            default:  // should be case INIT_FORKNUM, but set to default to keep compiler quiet
                 numBlocks = RelationGetNumberOfBlocksInFork(index, forkNum);
+                break;
         }
 
-        uint32_t    estimated_row_count = 0;
+        uint32_t estimated_row_count = 0;
         if(numBlocks > 0) {
             // Read the first block
             Buffer buffer = ReadBufferExtended(heap, MAIN_FORKNUM, 0, RBM_NORMAL, NULL);
@@ -474,7 +475,7 @@ static void BuildIndex(
 
         UpdateProgress(PROGRESS_CREATEIDX_PHASE, PROGRESS_HNSW_PHASE_IN_MEMORY_INSERT);
 
-        if (buildstate->heap != NULL) {
+        if(buildstate->heap != NULL) {
             LanternBench("build hnsw index", ScanTable(buildstate));
         }
 
@@ -528,8 +529,8 @@ IndexBuildResult *ldb_ambuild(Relation heap, Relation index, IndexInfo *indexInf
 void ldb_ambuildunlogged(Relation index)
 {
     // Manually construct index info
-    IndexInfo      *indexInfo = BuildIndexInfo(index);
-    HnswBuildState  buildState;
+    IndexInfo     *indexInfo = BuildIndexInfo(index);
+    HnswBuildState buildState;
 
     BuildIndex(NULL, index, indexInfo, &buildState, INIT_FORKNUM);
 }

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -176,7 +176,7 @@ bool ldb_aminsert(Relation         index,
         XLogRecPtr ptr = GenericXLogFinish(state);
 
         // If the table is unlogged, GenericXLogFinish returns InvalidXLogRecPtr as saving to WAL is not required.
-        if (!RelationNeedsWAL(index)) {
+        if(!RelationNeedsWAL(index)) {
             assert(ptr == InvalidXLogRecPtr);
         } else {
             assert(ptr != InvalidXLogRecPtr);

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -174,7 +174,13 @@ bool ldb_aminsert(Relation         index,
     {
         // GenericXLogFinish also calls MarkBufferDirty(buf)
         XLogRecPtr ptr = GenericXLogFinish(state);
-        assert(ptr != InvalidXLogRecPtr);
+
+        // If the table is unlogged, GenericXLogFinish returns InvalidXLogRecPtr as saving to WAL is not required.
+        if (!RelationNeedsWAL(index)) {
+            assert(ptr == InvalidXLogRecPtr);
+        } else {
+            assert(ptr != InvalidXLogRecPtr);
+        }
         LDB_UNUSED(ptr);
     }
 

--- a/test/expected/hnsw_unlogged.out
+++ b/test/expected/hnsw_unlogged.out
@@ -1,0 +1,185 @@
+---------------------------------------------------------------------
+-- Test support for unlogged tables
+---------------------------------------------------------------------
+-- Test insertion and index creation on an empty unlogged table
+CREATE UNLOGGED TABLE small_world_unlogged (
+    id varchar(3),
+    vector real[]
+);
+INSERT INTO small_world_unlogged (id, vector) VALUES
+('000', '{1,0,0,0}'),
+('001', '{1,0,0,1}'),
+('010', '{1,0,1,0}'),
+('011', '{1,0,1,1}'),
+('100', '{1,1,0,0}'),
+('101', '{1,1,0,1}'),
+('110', '{1,1,1,0}'),
+('111', '{1,1,1,1}');
+CREATE INDEX small_world4_hnsw_idx ON small_world_unlogged USING hnsw (vector) WITH (M=14, ef=22, ef_construction=2);
+INFO:  done init usearch index
+INFO:  inserted 8 elements
+INFO:  done saving 8 vectors
+INFO:  done init usearch index for unlogged table
+-- Creating the index should not prevent further insertions
+INSERT INTO small_world_unlogged (id, vector) VALUES
+('000', '{1,0,0,0}'),
+('001', '{1,0,0,1}'),
+('010', '{1,0,1,0}');
+-- Attempt to insert a row with an incorrect vector length
+\set ON_ERROR_STOP off
+INSERT INTO small_world_unlogged (id, vector) VALUES ('111', '{1,1,1}');
+ERROR:  Wrong number of dimensions: 3 instead of 4 expected
+\set ON_ERROR_STOP on
+-- Verify that the index works
+SET enable_seqscan = false;
+SELECT * FROM ldb_get_indexes('small_world_unlogged');
+       indexname       | size  |                                                             indexdef                                                              | total_index_size 
+-----------------------+-------+-----------------------------------------------------------------------------------------------------------------------------------+------------------
+ small_world4_hnsw_idx | 24 kB | CREATE INDEX small_world4_hnsw_idx ON public.small_world_unlogged USING hnsw (vector) WITH (m='14', ef='22', ef_construction='2') | 24 kB
+(1 row)
+
+SELECT vector AS vector000 FROM small_world_unlogged WHERE id = '000';
+ vector000 
+-----------
+ {1,0,0,0}
+ {1,0,0,0}
+(2 rows)
+
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(vector, '{1,0,0,0}')::numeric, 2) FROM small_world_unlogged;
+            QUERY PLAN            
+----------------------------------
+ Seq Scan on small_world_unlogged
+(1 row)
+
+SELECT ROUND(l2sq_dist(vector, '{1,0,0,0}')::numeric, 2) FROM small_world_unlogged;
+ round 
+-------
+  0.00
+  1.00
+  1.00
+  2.00
+  1.00
+  2.00
+  2.00
+  3.00
+  0.00
+  1.00
+  1.00
+(11 rows)
+
+DROP TABLE small_world_unlogged;
+-- Validate that creating an index from file works
+\ir utils/sift1k_array_unlogged.sql
+CREATE UNLOGGED TABLE IF NOT EXISTS sift_base1k_unlogged (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k_unlogged (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+CREATE INDEX hnsw_l2_index ON sift_base1k_unlogged USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+INFO:  done init usearch index for unlogged table
+SELECT * FROM ldb_get_indexes('sift_base1k_unlogged');
+   indexname   |  size  |                                                                       indexdef                                                                        | total_index_size 
+---------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k_unlogged USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch') | 720 kB
+(1 row)
+
+SELECT v AS v777 FROM sift_base1k_unlogged WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_l2_index on sift_base1k_unlogged
+         Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v777' LIMIT 10;
+   round   
+-----------
+      0.00
+  98486.00
+ 108785.00
+ 115194.00
+ 117411.00
+ 127293.00
+ 127986.00
+ 130663.00
+ 130863.00
+ 132455.00
+(10 rows)
+
+-- Validate that inserting rows on index created from file works as expected
+INSERT INTO sift_base1k_unlogged (id, v) VALUES 
+(1001, array_fill(1, ARRAY[128])),
+(1002, array_fill(2, ARRAY[128]));
+SELECT v AS v1001 FROM sift_base1k_unlogged WHERE id = 1001 \gset
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v1001' LIMIT 10;
+   round   
+-----------
+      0.00
+    128.00
+ 249249.00
+ 249285.00
+ 249418.00
+ 249457.00
+ 249515.00
+ 249589.00
+ 249647.00
+ 249652.00
+(10 rows)
+
+DROP TABLE sift_base1k_unlogged CASCADE;
+-- Verify that unlogged tables work with the l2sq_ops distance function
+\ir utils/small_world_array_unlogged.sql
+CREATE UNLOGGED TABLE small_world_unlogged (
+    id VARCHAR(3),
+    b BOOLEAN,
+    v REAL[3]
+);
+INSERT INTO small_world_unlogged (id, b, v) VALUES
+    ('000', TRUE,  '{0,0,0}'),
+    ('001', TRUE,  '{0,0,1}'),
+    ('010', FALSE, '{0,1,0}'),
+    ('011', TRUE,  '{0,1,1}'),
+    ('100', FALSE, '{1,0,0}'),
+    ('101', FALSE, '{1,0,1}'),
+    ('110', FALSE, '{1,1,0}'),
+    ('111', TRUE,  '{1,1,1}');
+CREATE UNLOGGED TABLE small_world_l2_unlogged (id VARCHAR(3), vector REAL[]);
+CREATE INDEX ON small_world_l2_unlogged USING hnsw (vector dist_l2sq_ops) WITH (dim=3);
+INFO:  done init usearch index
+INFO:  inserted 0 elements
+INFO:  done saving 0 vectors
+INFO:  done init usearch index for unlogged table
+INSERT INTO small_world_l2_unlogged SELECT id, v FROM small_world_unlogged;
+SELECT ROUND(l2sq_dist(vector, '{0,1,0}')::numeric, 2) FROM small_world_l2_unlogged ORDER BY vector <-> '{0,1,0}';
+ round 
+-------
+  0.00
+  1.00
+  1.00
+  1.00
+  2.00
+  2.00
+  2.00
+  3.00
+(8 rows)
+
+SELECT ARRAY_AGG(id ORDER BY id), ROUND(l2sq_dist(vector, '{0,1,0}')::numeric, 2) FROM small_world_l2_unlogged GROUP BY 2 ORDER BY 2;
+   array_agg   | round 
+---------------+-------
+ {010}         |  0.00
+ {000,011,110} |  1.00
+ {001,100,111} |  2.00
+ {101}         |  3.00
+(4 rows)
+
+EXPLAIN SELECT id FROM small_world_l2_unlogged ORDER BY vector <-> '{0,1,0}';
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Index Scan using small_world_l2_unlogged_vector_idx on small_world_l2_unlogged  (cost=0.00..60.05 rows=1070 width=20)
+   Order By: (vector <-> '{0,1,0}'::real[])
+(2 rows)
+

--- a/test/expected/hnsw_unlogged.out
+++ b/test/expected/hnsw_unlogged.out
@@ -19,7 +19,9 @@ CREATE INDEX small_world4_hnsw_idx ON small_world_unlogged USING hnsw (vector) W
 INFO:  done init usearch index
 INFO:  inserted 8 elements
 INFO:  done saving 8 vectors
-INFO:  done init usearch index for unlogged table
+INFO:  done init usearch index
+INFO:  inserted 0 elements
+INFO:  done saving 0 vectors
 -- Creating the index should not prevent further insertions
 INSERT INTO small_world_unlogged (id, vector) VALUES
 ('000', '{1,0,0,0}'),
@@ -79,7 +81,9 @@ CREATE INDEX hnsw_l2_index ON sift_base1k_unlogged USING hnsw (v) WITH (_experim
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
-INFO:  done init usearch index for unlogged table
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
 SELECT * FROM ldb_get_indexes('sift_base1k_unlogged');
    indexname   |  size  |                                                                       indexdef                                                                        | total_index_size 
 ---------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
@@ -152,7 +156,9 @@ CREATE INDEX ON small_world_l2_unlogged USING hnsw (vector dist_l2sq_ops) WITH (
 INFO:  done init usearch index
 INFO:  inserted 0 elements
 INFO:  done saving 0 vectors
-INFO:  done init usearch index for unlogged table
+INFO:  done init usearch index
+INFO:  inserted 0 elements
+INFO:  done saving 0 vectors
 INSERT INTO small_world_l2_unlogged SELECT id, v FROM small_world_unlogged;
 SELECT ROUND(l2sq_dist(vector, '{0,1,0}')::numeric, 2) FROM small_world_l2_unlogged ORDER BY vector <-> '{0,1,0}';
  round 

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -4,4 +4,4 @@
 # - 'test' lines may have multiple space-separated tests. All tests in a single 'test' line will be run in parallel
 
 test_pgvector: hnsw_vector
-test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate
+test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate hnsw_unlogged

--- a/test/sql/hnsw_unlogged.sql
+++ b/test/sql/hnsw_unlogged.sql
@@ -1,0 +1,67 @@
+---------------------------------------------------------------------
+-- Test support for unlogged tables
+---------------------------------------------------------------------
+
+-- Test insertion and index creation on an empty unlogged table
+CREATE UNLOGGED TABLE small_world_unlogged (
+    id varchar(3),
+    vector real[]
+);
+
+INSERT INTO small_world_unlogged (id, vector) VALUES
+('000', '{1,0,0,0}'),
+('001', '{1,0,0,1}'),
+('010', '{1,0,1,0}'),
+('011', '{1,0,1,1}'),
+('100', '{1,1,0,0}'),
+('101', '{1,1,0,1}'),
+('110', '{1,1,1,0}'),
+('111', '{1,1,1,1}');
+
+CREATE INDEX small_world4_hnsw_idx ON small_world_unlogged USING hnsw (vector) WITH (M=14, ef=22, ef_construction=2);
+
+-- Creating the index should not prevent further insertions
+INSERT INTO small_world_unlogged (id, vector) VALUES
+('000', '{1,0,0,0}'),
+('001', '{1,0,0,1}'),
+('010', '{1,0,1,0}');
+
+-- Attempt to insert a row with an incorrect vector length
+\set ON_ERROR_STOP off
+INSERT INTO small_world_unlogged (id, vector) VALUES ('111', '{1,1,1}');
+\set ON_ERROR_STOP on
+
+-- Verify that the index works
+SET enable_seqscan = false;
+SELECT * FROM ldb_get_indexes('small_world_unlogged');
+SELECT vector AS vector000 FROM small_world_unlogged WHERE id = '000';
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(vector, '{1,0,0,0}')::numeric, 2) FROM small_world_unlogged;
+SELECT ROUND(l2sq_dist(vector, '{1,0,0,0}')::numeric, 2) FROM small_world_unlogged;
+
+DROP TABLE small_world_unlogged;
+
+-- Validate that creating an index from file works
+\ir utils/sift1k_array_unlogged.sql
+CREATE INDEX hnsw_l2_index ON sift_base1k_unlogged USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch');
+SELECT * FROM ldb_get_indexes('sift_base1k_unlogged');
+SELECT v AS v777 FROM sift_base1k_unlogged WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v777' LIMIT 10;
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v777' LIMIT 10;
+
+-- Validate that inserting rows on index created from file works as expected
+INSERT INTO sift_base1k_unlogged (id, v) VALUES 
+(1001, array_fill(1, ARRAY[128])),
+(1002, array_fill(2, ARRAY[128]));
+SELECT v AS v1001 FROM sift_base1k_unlogged WHERE id = 1001 \gset
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k_unlogged order by v <-> :'v1001' LIMIT 10;
+
+DROP TABLE sift_base1k_unlogged CASCADE;
+
+-- Verify that unlogged tables work with the l2sq_ops distance function
+\ir utils/small_world_array_unlogged.sql
+CREATE UNLOGGED TABLE small_world_l2_unlogged (id VARCHAR(3), vector REAL[]);
+CREATE INDEX ON small_world_l2_unlogged USING hnsw (vector dist_l2sq_ops) WITH (dim=3);
+INSERT INTO small_world_l2_unlogged SELECT id, v FROM small_world_unlogged;
+SELECT ROUND(l2sq_dist(vector, '{0,1,0}')::numeric, 2) FROM small_world_l2_unlogged ORDER BY vector <-> '{0,1,0}';
+SELECT ARRAY_AGG(id ORDER BY id), ROUND(l2sq_dist(vector, '{0,1,0}')::numeric, 2) FROM small_world_l2_unlogged GROUP BY 2 ORDER BY 2;
+EXPLAIN SELECT id FROM small_world_l2_unlogged ORDER BY vector <-> '{0,1,0}';

--- a/test/sql/utils/sift1k_array_unlogged.sql
+++ b/test/sql/utils/sift1k_array_unlogged.sql
@@ -1,0 +1,6 @@
+CREATE UNLOGGED TABLE IF NOT EXISTS sift_base1k_unlogged (
+    id SERIAL,
+    v REAL[]
+);
+
+COPY sift_base1k_unlogged (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' WITH csv;

--- a/test/sql/utils/small_world_array_unlogged.sql
+++ b/test/sql/utils/small_world_array_unlogged.sql
@@ -1,0 +1,15 @@
+CREATE UNLOGGED TABLE small_world_unlogged (
+    id VARCHAR(3),
+    b BOOLEAN,
+    v REAL[3]
+);
+
+INSERT INTO small_world_unlogged (id, b, v) VALUES
+    ('000', TRUE,  '{0,0,0}'),
+    ('001', TRUE,  '{0,0,1}'),
+    ('010', FALSE, '{0,1,0}'),
+    ('011', TRUE,  '{0,1,1}'),
+    ('100', FALSE, '{1,0,0}'),
+    ('101', FALSE, '{1,0,1}'),
+    ('110', FALSE, '{1,1,0}'),
+    ('111', TRUE,  '{1,1,1}');


### PR DESCRIPTION
This PR adds support for unlogged tables, ensuring that Lantern functionality works correctly even if the current table is not saved to WAL. A corresponding test (and associated util testing scripts) have been added to make test to verify that unlogged table functionality behaves as expected.

NOTE: Currently the test checks inserts and index creation on an empty unlogged table as well as one retrieved from file. It also verifies that the created index works and that distance functions work on unlogged tables. Let me know if there are other cases that should be covered, and I'll be happy to add them!