### PR TITLE
Fix test runner for parallel tests

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -125,7 +125,6 @@ if [[ -n "$FILTER" || -n "$EXCLUDE" ]]; then
     while IFS= read -r f; do
         if [ -n "$FILTER" ]; then
             if [[ $f == *"$FILTER"* ]]; then
-                echo "HERE $f"
                 print_test $f $TMP_OUTDIR/schedule.txt $FIRST_TEST
             fi
         elif [ -n "$EXCLUDE" ]; then

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -52,8 +52,10 @@ function run_regression_test {
 cd sql/
 
 # install lantern extension
-psql "$@" -U ${DB_USER} -d postgres -v ECHO=none -q -c "DROP DATABASE IF EXISTS ${TEST_CASE_DB};" 2>/dev/null
-psql "$@" -U ${DB_USER} -d postgres -v ECHO=none -q -c "CREATE DATABASE ${TEST_CASE_DB};" 2>/dev/null
+if [[ "$PARALLEL" -eq 0 || "$TESTFILE_NAME" == "begin" ]]; then
+     psql "$@" -U ${DB_USER} -d postgres -v ECHO=none -q -c "DROP DATABASE IF EXISTS ${TEST_CASE_DB};" 2>/dev/null
+     psql "$@" -U ${DB_USER} -d postgres -v ECHO=none -q -c "CREATE DATABASE ${TEST_CASE_DB};" 2>/dev/null
+fi
 if [ ! -z "$UPDATE_EXTENSION" ]
 then
      if [ -z "$UPDATE_FROM" ] || [ -z "$UPDATE_TO" ]


### PR DESCRIPTION
In parallel tests we should only drop the database when starting the tests (if test file is `begin.sql`) as all the test are running against the same database.