### PR TITLE
Narek/ezra work mem

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -9,7 +9,6 @@
 #include <catalog/pg_type.h>
 #include <executor/executor.h>
 #include <funcapi.h>
-#include <math.h>
 #include <miscadmin.h>
 #include <nodes/execnodes.h>
 #include <storage/bufmgr.h>
@@ -94,15 +93,12 @@ static void AddTupleToUsearchIndex(ItemPointer tid, Datum *values, HnswBuildStat
     if(buildstate->usearch_index != NULL) {
         size_t capacity = usearch_capacity(buildstate->usearch_index, &error);
         if(capacity == usearch_size(buildstate->usearch_index, &error)) {
-            double             M = ldb_HnswGetM(index);
-            double             mL = 1 / log(M);
-            usearch_metadata_t meta = usearch_metadata(buildstate->usearch_index, &error);
-            uint32             node_size = UsearchNodeBytes(&meta, meta.dimensions * sizeof(float), (int)(mL + .5));
-            if(2 * usearch_size(buildstate->usearch_index, &error) * node_size
-               >= (size_t)maintenance_work_mem * 1024L) {
-                usearch_free(buildstate->usearch_index, &error);
-                elog(ERROR, "index size exceeded maintenance_work_mem during index construction");
-            }
+            CheckMem(maintenance_work_mem,
+                     index,
+                     buildstate->usearch_index,
+                     2 * usearch_size(buildstate->usearch_index, &error),
+                     "index size exceeded maintenance_work_mem during index construction, consider increasing "
+                     "maintenance_work_mem");
             usearch_reserve(buildstate->usearch_index, 2 * capacity, &error);
             assert(error == NULL);
         }
@@ -464,14 +460,12 @@ static void BuildIndex(
             // Unlock and release buffer
             UnlockReleaseBuffer(buffer);
         }
-        double             M = ldb_HnswGetM(index);
-        double             mL = 1 / log(M);
-        usearch_metadata_t meta = usearch_metadata(buildstate->usearch_index, &error);
-        uint32             node_size = UsearchNodeBytes(&meta, opts.dimensions * sizeof(float), (int)(mL + .5));
-        // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
-        if(node_size * estimated_row_count > maintenance_work_mem * 1024L) {
-            elog(ERROR, "index size exceeded maintenance_work_mem during index construction");
-        }
+        CheckMem(maintenance_work_mem,
+                 index,
+                 buildstate->usearch_index,
+                 estimated_row_count,
+                 "index size exceeded maintenance_work_mem during index construction, consider increasing "
+                 "maintenance_work_mem");
         usearch_reserve(buildstate->usearch_index, estimated_row_count, &error);
         if(error != NULL) {
             // There's not much we can do if free throws an error, but we want to preserve the contents of the first one

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -638,7 +638,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
 #endif
         }
         if(ctx->memory >= work_mem * 1024L) {
-            elog(ERROR, "pinned more buffers during query than will fit in work_mem, consider increasing work_mem");
+            elog(WARNING, "pinned more buffers during query than will fit in work_mem, consider increasing work_mem");
         }
     }
     if(!idx_page_prelocked) {

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -630,17 +630,13 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
 
-<<<<<<< HEAD
-            fa_cache_insert(&ctx->fa_cache, id, nodepage->node);
-=======
             CheckMem(work_mem,
                      NULL,
                      NULL,
                      0,
                      "Pinned more tuples during node retrieval than will fir in work_mem, cosider increasing work_mem");
+            fa_cache_insert(&ctx->fa_cache, id, nodepage->node);
 
-            cache_set_item(&ctx->node_cache, &id, nodepage->node);
->>>>>>> 1175c02 (add test back in to external_index, fix elog in CheckMem)
 
             return nodepage->node;
 #endif

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -638,7 +638,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                      NULL,
                      NULL,
                      0,
-                     "Pinned more tuples during node retrieval than will fir in work_mem, cosider increasing work_mem");
+                     "pinned more tuples during node retrieval than will fit in work_mem, cosider increasing work_mem");
 #endif
             fa_cache_insert(&ctx->fa_cache, id, nodepage->node);
 

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -22,7 +22,7 @@
 
 static BlockNumber getBlockMapPageBlockNumber(uint32 *blockmap_page_group_index, int id);
 
-static uint32 UsearchNodeBytes(usearch_metadata_t *metadata, int vector_bytes, int level)
+uint32 UsearchNodeBytes(usearch_metadata_t *metadata, int vector_bytes, int level)
 {
     const int NODE_HEAD_BYTES = sizeof(usearch_label_t) + 4 /*sizeof dim */ + 4 /*sizeof level*/;
     uint32    node_bytes = 0;

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -7,7 +7,6 @@
 #include <assert.h>
 #include <common/relpath.h>
 #include <hnsw/fa_cache.h>
-#include <miscadmin.h>
 #include <pg_config.h>       // BLCKSZ
 #include <storage/bufmgr.h>  // Buffer
 #include <utils/hsearch.h>
@@ -20,6 +19,10 @@
 #include "retriever.h"
 #include "usearch.h"
 #include "utils.h"
+
+#if PG_VERSION_NUM >= 120000
+#include <miscadmin.h>
+#endif
 
 static BlockNumber getBlockMapPageBlockNumber(uint32 *blockmap_page_group_index, int id);
 
@@ -630,13 +633,14 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
 
+#if PG_VERSION_NUM >= 120000
             CheckMem(work_mem,
                      NULL,
                      NULL,
                      0,
                      "Pinned more tuples during node retrieval than will fir in work_mem, cosider increasing work_mem");
+#endif
             fa_cache_insert(&ctx->fa_cache, id, nodepage->node);
-
 
             return nodepage->node;
 #endif

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -630,7 +630,17 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
 
+<<<<<<< HEAD
             fa_cache_insert(&ctx->fa_cache, id, nodepage->node);
+=======
+            CheckMem(work_mem,
+                     NULL,
+                     NULL,
+                     0,
+                     "Pinned more tuples during node retrieval than will fir in work_mem, cosider increasing work_mem");
+
+            cache_set_item(&ctx->node_cache, &id, nodepage->node);
+>>>>>>> 1175c02 (add test back in to external_index, fix elog in CheckMem)
 
             return nodepage->node;
 #endif

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -616,7 +616,6 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
             if(!idx_page_prelocked) {
                 UnlockReleaseBuffer(buf);
             }
-            ctx->memory += sizeof(BufferNode) + nodepage->size;
             dlist_push_tail(&ctx->takenbuffers, &buffNode->node);
             return buffNode->buf;
 #else
@@ -627,7 +626,6 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 buffNode->buf = buf;
 
                 // Add buffNode to list of pinned buffers
-                ctx->memory += sizeof(BufferNode) + offsetof(HnswIndexTuple, node) + nodepage->size;
                 dlist_push_tail(&ctx->takenbuffers, &buffNode->node);
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
@@ -636,9 +634,6 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
 
             return nodepage->node;
 #endif
-        }
-        if(ctx->memory >= work_mem * 1024L) {
-            elog(WARNING, "pinned more buffers during query than will fit in work_mem, consider increasing work_mem");
         }
     }
     if(!idx_page_prelocked) {

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -20,7 +20,7 @@
 #include "usearch.h"
 #include "utils.h"
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM > 120000
 #include <miscadmin.h>
 #endif
 
@@ -633,7 +633,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM > 120000
             CheckMem(work_mem,
                      NULL,
                      NULL,

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -20,7 +20,7 @@
 #include "usearch.h"
 #include "utils.h"
 
-#if PG_VERSION_NUM > 120000
+#if PG_VERSION_NUM >= 130000
 #include <miscadmin.h>
 #endif
 
@@ -633,7 +633,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, int id)
                 LockBuffer(buf, BUFFER_LOCK_UNLOCK);
             }
 
-#if PG_VERSION_NUM > 120000
+#if PG_VERSION_NUM >= 130000
             CheckMem(work_mem,
                      NULL,
                      NULL,

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -112,12 +112,13 @@ typedef struct
     HnswColumnType  columnType;
 } HnswInsertState;
 
-void StoreExternalIndex(Relation                index,
-                        usearch_index_t         external_index,
-                        ForkNumber              forkNum,
-                        char                   *data,
-                        usearch_init_options_t *opts,
-                        size_t                  num_added_vectors);
+uint32 UsearchNodeBytes(usearch_metadata_t *metadata, int vector_bytes, int level);
+void   StoreExternalIndex(Relation                index,
+                          usearch_index_t         external_index,
+                          ForkNumber              forkNum,
+                          char                   *data,
+                          usearch_init_options_t *opts,
+                          size_t                  num_added_vectors);
 
 // add the fully constructed index tuple to the index via wal
 // hdr is passed in so num_vectors, first_block_no, last_block_no can be updated

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -93,6 +93,8 @@ typedef struct
     FullyAssociativeCache fa_cache;
 
     dlist_head takenbuffers;
+
+    int memory;
 } RetrieverCtx;
 
 typedef struct

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -93,8 +93,6 @@ typedef struct
     FullyAssociativeCache fa_cache;
 
     dlist_head takenbuffers;
-
-    int memory;
 } RetrieverCtx;
 
 typedef struct

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -145,13 +145,11 @@ bool ldb_aminsert(Relation         index,
     assert(hdr->magicNumber == LDB_WAL_MAGIC_NUMBER);
     ldb_dlog("Insert: at start num vectors is %d", hdr->num_vectors);
 
-    double M = ldb_HnswGetM(index);
-    double mL = 1 / log(M);
-    uint32 node_size = UsearchNodeBytes(&meta, opts.dimensions * sizeof(float), (int)(mL + .5));
-    // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
-    if(node_size * (hdr->num_vectors + 1) > work_mem * 1024L) {
-        elog(WARNING, "index size exceeded work_mem during insert");
-    }
+    CheckMem(work_mem,
+             index,
+             uidx,
+             hdr->num_vectors,
+             "index size exceeded work_mem during insert, consider increasing work_mem");
 
     usearch_reserve(uidx, hdr->num_vectors + 1, &error);
     uint32 level = hnsw_generate_new_level(meta.connectivity);

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -9,6 +9,7 @@
 #endif
 #include <float.h>
 #include <math.h>
+#include <miscadmin.h>
 #include <storage/bufmgr.h>
 #include <utils/array.h>
 #include <utils/rel.h>
@@ -143,6 +144,15 @@ bool ldb_aminsert(Relation         index,
 
     assert(hdr->magicNumber == LDB_WAL_MAGIC_NUMBER);
     ldb_dlog("Insert: at start num vectors is %d", hdr->num_vectors);
+
+    double M = ldb_HnswGetM(index);
+    double mL = 1 / log(M);
+    uint32 node_size = UsearchNodeBytes(&meta, opts.dimensions * sizeof(float), (int)(mL + .5));
+    // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
+    if (node_size * (hdr->num_vectors + 1) > work_mem * 1024L) {
+        usearch_free(uidx, &error);
+        elog(ERROR, "index size exceeded work_mem during insert");
+    }
 
     usearch_reserve(uidx, hdr->num_vectors + 1, &error);
     uint32 level = hnsw_generate_new_level(meta.connectivity);

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -149,7 +149,7 @@ bool ldb_aminsert(Relation         index,
     double mL = 1 / log(M);
     uint32 node_size = UsearchNodeBytes(&meta, opts.dimensions * sizeof(float), (int)(mL + .5));
     // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
-    if (node_size * (hdr->num_vectors + 1) > work_mem * 1024L) {
+    if(node_size * (hdr->num_vectors + 1) > work_mem * 1024L) {
         elog(WARNING, "index size exceeded work_mem during insert");
     }
 

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -150,8 +150,7 @@ bool ldb_aminsert(Relation         index,
     uint32 node_size = UsearchNodeBytes(&meta, opts.dimensions * sizeof(float), (int)(mL + .5));
     // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
     if (node_size * (hdr->num_vectors + 1) > work_mem * 1024L) {
-        usearch_free(uidx, &error);
-        elog(ERROR, "index size exceeded work_mem during insert");
+        elog(WARNING, "index size exceeded work_mem during insert");
     }
 
     usearch_reserve(uidx, hdr->num_vectors + 1, &error);

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -27,8 +27,6 @@ RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPag
     /* fill in a buffer with blockno index information, before spilling it to disk */
     ctx->block_numbers_cache = cache_create("BlockNumberCache");
 
-    ctx->memory = 0;
-
     return ctx;
 }
 
@@ -49,8 +47,6 @@ void ldb_wal_retriever_area_reset(RetrieverCtx *ctx, HnswIndexHeaderPage *header
         pfree(node);
     }
     dlist_init(&ctx->takenbuffers);
-
-    ctx->memory = 0;
 
     assert(ctx->header_page_under_wal == header_page_under_wal);
     ctx->header_page_under_wal = header_page_under_wal;

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -27,6 +27,8 @@ RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPag
     /* fill in a buffer with blockno index information, before spilling it to disk */
     ctx->block_numbers_cache = cache_create("BlockNumberCache");
 
+    ctx->memory = 0;
+
     return ctx;
 }
 
@@ -47,6 +49,8 @@ void ldb_wal_retriever_area_reset(RetrieverCtx *ctx, HnswIndexHeaderPage *header
         pfree(node);
     }
     dlist_init(&ctx->takenbuffers);
+
+    ctx->memory = 0;
 
     assert(ctx->header_page_under_wal == header_page_under_wal);
     ctx->header_page_under_wal = header_page_under_wal;

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -194,14 +194,14 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
             scanstate->labels = palloc(k * sizeof(usearch_label_t));
         }
 
-        double M = ldb_HnswGetM(scan->indexRelation);
-        double mL = 1 / log(M);
+        double             M = ldb_HnswGetM(scan->indexRelation);
+        double             mL = 1 / log(M);
         usearch_metadata_t meta = usearch_metadata(scanstate->usearch_index, &error);
-        uint32 node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
+        uint32             node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
         // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
         // I think because of mem_view_lazy a max of k nodes will be held in memory by usearch
         // there are separate checks on the memory held by takenbuffers
-        if (node_size * k > work_mem * 1024L) {
+        if(node_size * k > work_mem * 1024L) {
             elog(WARNING, "index size exceeded work_mem during scan");
         }
 
@@ -240,11 +240,11 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
         scanstate->distances = repalloc(scanstate->distances, k * sizeof(float));
         scanstate->labels = repalloc(scanstate->labels, k * sizeof(usearch_label_t));
 
-        double M = ldb_HnswGetM(scan->indexRelation);
-        double mL = 1 / log(M);
+        double             M = ldb_HnswGetM(scan->indexRelation);
+        double             mL = 1 / log(M);
         usearch_metadata_t meta = usearch_metadata(scanstate->usearch_index, &error);
-        uint32 node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
-        if (node_size * k > work_mem * 1024L) {
+        uint32             node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
+        if(node_size * k > work_mem * 1024L) {
             elog(WARNING, "index size exceeded work_mem during scan");
         }
 

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -202,8 +202,7 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
         // I think because of mem_view_lazy a max of k nodes will be held in memory by usearch
         // there are separate checks on the memory held by takenbuffers
         if (node_size * k > work_mem * 1024L) {
-            usearch_free(scanstate->usearch_index, &error);
-            elog(ERROR, "index size exceeded work_mem during insert");
+            elog(WARNING, "index size exceeded work_mem during scan");
         }
 
         ldb_dlog("LANTERN querying index for %d elements", k);
@@ -246,8 +245,7 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
         usearch_metadata_t meta = usearch_metadata(scanstate->usearch_index, &error);
         uint32 node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
         if (node_size * k > work_mem * 1024L) {
-            usearch_free(scanstate->usearch_index, &error);
-            elog(ERROR, "index size exceeded work_mem during insert");
+            elog(WARNING, "index size exceeded work_mem during scan");
         }
 
         ldb_dlog("LANTERN - querying index for %d elements", k);

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -3,7 +3,6 @@
 #include "scan.h"
 
 #include <access/relscan.h>
-#include <math.h>
 #include <miscadmin.h>
 #include <pgstat.h>
 #include <utils/rel.h>
@@ -194,17 +193,11 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
             scanstate->labels = palloc(k * sizeof(usearch_label_t));
         }
 
-        double             M = ldb_HnswGetM(scan->indexRelation);
-        double             mL = 1 / log(M);
-        usearch_metadata_t meta = usearch_metadata(scanstate->usearch_index, &error);
-        uint32             node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
-        // accuracy could be improved by not rounding mL, but otherwise this will never be fully accurate
-        // I think because of mem_view_lazy a max of k nodes will be held in memory by usearch
-        // there are separate checks on the memory held by takenbuffers
-        if(node_size * k > work_mem * 1024L) {
-            elog(WARNING, "index size exceeded work_mem during scan");
-        }
-
+        CheckMem(work_mem,
+                 scan->indexRelation,
+                 scanstate->usearch_index,
+                 k,
+                 "index size exceeded work_mem during scan, consider increasing work_mem");
         ldb_dlog("LANTERN querying index for %d elements", k);
         num_returned = usearch_search(
             scanstate->usearch_index, vec, usearch_scalar_f32_k, k, scanstate->labels, scanstate->distances, &error);
@@ -240,13 +233,11 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
         scanstate->distances = repalloc(scanstate->distances, k * sizeof(float));
         scanstate->labels = repalloc(scanstate->labels, k * sizeof(usearch_label_t));
 
-        double             M = ldb_HnswGetM(scan->indexRelation);
-        double             mL = 1 / log(M);
-        usearch_metadata_t meta = usearch_metadata(scanstate->usearch_index, &error);
-        uint32             node_size = UsearchNodeBytes(&meta, scanstate->dimensions * sizeof(float), (int)(mL + .5));
-        if(node_size * k > work_mem * 1024L) {
-            elog(WARNING, "index size exceeded work_mem during scan");
-        }
+        CheckMem(work_mem,
+                 scan->indexRelation,
+                 scanstate->usearch_index,
+                 k,
+                 "index size exceeded work_mem during scan, consider increasing work_mem");
 
         ldb_dlog("LANTERN - querying index for %d elements", k);
         num_returned = usearch_search(

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -7,7 +7,10 @@
 #include <miscadmin.h>
 #include <regex.h>
 #include <string.h>
+
+#if PG_VERSION_NUM >= 120000
 #include <utils/memutils.h>
+#endif
 
 #include "external_index.h"
 #include "hnsw.h"
@@ -64,7 +67,12 @@ void CheckMem(int limit, Relation index, usearch_index_t uidx, uint32 n_nodes, c
         // todo:: update sizeof(float) to correct vector size once #19 is merged
         node_size = UsearchNodeBytes(&meta, meta.dimensions * sizeof(float), (int)round(mL + 1));
     }
+    // todo:: there's figure out a way to check this in pg <= 12
+#if PG_VERSION_NUM >= 120000
     Size pg_mem = MemoryContextMemAllocated(CurrentMemoryContext, true);
+#else
+    Size pg_mem = 0;
+#endif
 
     // The average number of layers for an element to be added in is mL+1 per section 4.2.2
     // Accuracy could maybe be improved by not rounding

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -3,9 +3,13 @@
 #include "utils.h"
 
 #include <assert.h>
+#include <math.h>
+#include <miscadmin.h>
 #include <regex.h>
 #include <string.h>
+#include <utils/memutils.h>
 
+#include "external_index.h"
 #include "hnsw.h"
 #include "options.h"
 #include "usearch.h"
@@ -47,4 +51,22 @@ usearch_label_t GetUsearchLabel(ItemPointer itemPtr)
     usearch_label_t label = 0;
     memcpy((unsigned long *)&label, itemPtr, 6);
     return label;
+}
+
+void CheckMem(int limit, Relation index, usearch_index_t uidx, uint32 n_nodes, char *msg)
+{
+    usearch_error_t    error;
+    double             M = ldb_HnswGetM(index);
+    double             mL = 1 / log(M);
+    usearch_metadata_t meta = usearch_metadata(uidx, &error);
+    // todo:: update sizeof(float) to correct vector size once #19 is merged
+    uint32 node_size = UsearchNodeBytes(&meta, meta.dimensions * sizeof(float), (int)round(mL + 1));
+    Size   pg_mem = MemoryContextMemAllocated(CurrentMemoryContext, true);
+
+    // The average number of layers for an element to be added in is mL+1 per section 4.2.2
+    // Accuracy could maybe be improved by not rounding
+    // This is a guess, but it's a reasonably good one
+    if(pg_mem + node_size * n_nodes > (uint32)limit * 1024UL) {
+        elog(WARNING, msg);
+    }
 }

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -8,7 +8,7 @@
 #include <regex.h>
 #include <string.h>
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM > 120000
 #include <utils/memutils.h>
 #endif
 
@@ -68,7 +68,7 @@ void CheckMem(int limit, Relation index, usearch_index_t uidx, uint32 n_nodes, c
         node_size = UsearchNodeBytes(&meta, meta.dimensions * sizeof(float), (int)round(mL + 1));
     }
     // todo:: there's figure out a way to check this in pg <= 12
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM > 120000
     Size pg_mem = MemoryContextMemAllocated(CurrentMemoryContext, true);
 #else
     Size pg_mem = 0;

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -8,7 +8,7 @@
 #include <regex.h>
 #include <string.h>
 
-#if PG_VERSION_NUM > 120000
+#if PG_VERSION_NUM >= 130000
 #include <utils/memutils.h>
 #endif
 
@@ -68,7 +68,7 @@ void CheckMem(int limit, Relation index, usearch_index_t uidx, uint32 n_nodes, c
         node_size = UsearchNodeBytes(&meta, meta.dimensions * sizeof(float), (int)round(mL + 1));
     }
     // todo:: there's figure out a way to check this in pg <= 12
-#if PG_VERSION_NUM > 120000
+#if PG_VERSION_NUM >= 130000
     Size pg_mem = MemoryContextMemAllocated(CurrentMemoryContext, true);
 #else
     Size pg_mem = 0;

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -5,6 +5,7 @@
 #include "options.h"
 #include "usearch.h"
 
+void            CheckMem(int limit, Relation index, usearch_index_t uidx, uint32 n_nodes, char *msg);
 void            LogUsearchOptions(usearch_init_options_t *opts);
 void            PopulateUsearchOpts(Relation index, usearch_init_options_t *opts);
 usearch_label_t GetUsearchLabel(ItemPointer itemPtr);

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -1,7 +1,12 @@
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on empty table
 ---------------------------------------------------------------------
-set work_mem = '10MB';
+-- set an artificially low work_mem to make sure work_mem exceeded warnings are printed
+set work_mem = '64kB';
+-- We do not actually print the warnings generated for exceeding work_mem because the work_mem
+-- check does not work for postgres 13 and lower.So, if we printed the warnings, we would get a regression
+-- failure in older postgres versions. We still reduce workmem to exercise relevant codepaths for coverage
+set client_min_messages = 'ERROR';
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,
     v REAL[2]
@@ -19,6 +24,9 @@ INSERT INTO small_world (v) VALUES ('{1,1,1,1}');
 ERROR:  Wrong number of dimensions: 4 instead of 3 expected
 \set ON_ERROR_STOP on
 DROP TABLE small_world;
+-- set work_mem to a value that is enough for the tests
+set client_min_messages = 'WARNING';
+set work_mem = '10MB';
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on non-empty table
 ---------------------------------------------------------------------

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -1,6 +1,7 @@
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on empty table
 ---------------------------------------------------------------------
+set work_mem = '10MB';
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,
     v REAL[2]

--- a/test/parallel/expected/insert.out
+++ b/test/parallel/expected/insert.out
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/parallel/expected/insert2.out
+++ b/test/parallel/expected/insert2.out
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/parallel/expected/insert3.out
+++ b/test/parallel/expected/insert3.out
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/parallel/sql/insert.sql
+++ b/test/parallel/sql/insert.sql
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/parallel/sql/insert2.sql
+++ b/test/parallel/sql/insert2.sql
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/parallel/sql/insert3.sql
+++ b/test/parallel/sql/insert3.sql
@@ -1,3 +1,4 @@
+SET work_mem='10MB';
 BEGIN;
 INSERT INTO sift_base10k (id, v) VALUES 
     (nextval('serial'), random_array(128, 0, 128)),

--- a/test/sql/hnsw_create.sql
+++ b/test/sql/hnsw_create.sql
@@ -17,6 +17,7 @@ SELECT v AS v4444 FROM sift_base10k WHERE id = 4444 \gset
 EXPLAIN (COSTS FALSE) SELECT * FROM sift_base10k order by v <-> :'v4444' LIMIT 10;
 
 --- Validate that M values inside the allowed range [2, 128] do not throw an error
+
 CREATE INDEX ON small_world USING hnsw (v) WITH (M=2);
 CREATE INDEX ON small_world USING hnsw (v) WITH (M=128);
 

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -1,7 +1,12 @@
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on empty table
 ---------------------------------------------------------------------
-set work_mem = '10MB';
+-- set an artificially low work_mem to make sure work_mem exceeded warnings are printed
+set work_mem = '64kB';
+-- We do not actually print the warnings generated for exceeding work_mem because the work_mem
+-- check does not work for postgres 13 and lower.So, if we printed the warnings, we would get a regression
+-- failure in older postgres versions. We still reduce workmem to exercise relevant codepaths for coverage
+set client_min_messages = 'ERROR';
 
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,
@@ -19,6 +24,10 @@ INSERT INTO small_world (v) VALUES ('{1,1,1,1}');
 \set ON_ERROR_STOP on
 
 DROP TABLE small_world;
+
+-- set work_mem to a value that is enough for the tests
+set client_min_messages = 'WARNING';
+set work_mem = '10MB';
 
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on non-empty table

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -1,6 +1,7 @@
 ---------------------------------------------------------------------
 -- Test HNSW index inserts on empty table
 ---------------------------------------------------------------------
+set work_mem = '10MB';
 
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
[Copied from Ezra's pr (#200):


This adds checks for the `work_mem` and `maintenance_work_mem` GUC variables. Checks for both are fairly uncommon in the upstream extensions. It seems like `maintenance_work_mem` is checked more often than `work_mem` this may be because it's greater size makes it less prohibitive to respect. Neither is actually enforced by postgres. I'll list some examples below 

`maintenance_work_mem` is referenced more infrequently but its use is pretty straightforward when it is
in `src/backend/access/gin/gininsert.c` in the build callback function `maintenance_work_mem` is checked
```
if (buildstate->accum.allocatedMemory >= (Size) maintenance_work_mem * 1024L)
```

similarly nbtree checks it in its parallel build functions `src/backend/access/nbtree/nbtsort.c`
```
 sortmem = maintenance_work_mem / btshared->scantuplesortstates;
 _bt_parallel_scan_and_sort(btspool, btspool2, btshared, sharedsort,
                                               sharedsort2, sortmem, false);
```
It is also checked in `src/backend/commands/vacuumparallel.c`. It is never checked in contrib. I think the `bloom` in the earlier listing refers to an internal bloomfilter, not the extension. Notably though pgvector does have a [check](https://github.com/pgvector/pgvector/blob/e630efd195c563496c3550abb1817303586ee46d/src/hnswbuild.c#L386-L400)

`work_mem` is also checked very infrequently although within the optimizer/executor there are a number of checks. 
in `src/backend/access/gin/ginfast.c` it gets checked
```
workMemory = work_mem;
...
/*
* Is it time to flush memory to disk?  Flush if we are at the end of
* the pending list, or if we have a full row and memory is getting
* full.
*/
if (GinPageGetOpaque(page)->rightlink == InvalidBlockNumber ||
    (GinPageHasFullRow(page) &&
    (accum.allocatedMemory >= workMemory * 1024L)))
```
it gets checked in `src/backend/access/nbtree/nbtpage.c` as well, albeit in a function that is only called during vacuums
```
maxbufsize = (work_mem * 1024L) / sizeof(BTPendingFSM);
maxbufsize = Min(maxbufsize, INT_MAX);
maxbufsize = Min(maxbufsize, MaxAllocSize / sizeof(BTPendingFSM));
/* Stay sane with small work_mem */
maxbufsize = Max(maxbufsize, vstate->bufsize);
vstate->maxbufsize = maxbufsize;
```
I have however found the following calling pattern in several places including `contrib/tablefunc/tablefunc.c`, `contrib/dblink/dblink.c`, `contrib/adminpack/adminpack.c` and also [pgvector](https://github.com/pgvector/pgvector/blob/e630efd195c563496c3550abb1817303586ee46d/src/ivfscan.c#L228) (albeit only in ivfscans)
```
tuplestore_begin_heap(random_access, false, work_mem);
```
this seems to be a data structure that holds tuples to be returned by a scan. It doesn't account for memory allocated elsewhere though. Overall the lack of enforcement seems to make checking these values somewhat uncommon. I think it makes sense to enforce `maintenance_work_mem` because building an index is relatively infrequent, but maybe enforcing runtime checks for `work_mem` is overkill