### PR TITLE
add action to run against asan

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -136,7 +136,7 @@ jobs:
       run: |
         make -C ~/$PG_SRC_DIR install
         echo $PG_INSTALL_DIR/bin >> $GITHUB_PATH
-        sudo chown -R 755 $PG_INSTALL_DIR/bin
+        sudo chmod -R 755 $PG_INSTALL_DIR/bin
         $PG_INSTALL_DIR/bin/pg_config --version
 
     - name: Build Lantern

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -109,6 +109,7 @@ jobs:
           -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
     - name: Build PostgreSQL ${{ matrix.pg }} if not in cache
+      id: build-postgresql
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
         wget -q -O postgresql.tar.bz2 \
@@ -124,6 +125,15 @@ jobs:
         make -j$(nproc)
         make -j$(nproc) -C contrib/pageinspect
         make -j$(nproc) -C src/test/isolation
+        echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+    - name: save cache preemptively if postgres built
+      uses: actions/cache/save@v3
+      if: steps.build-postgresql.outputs.exit_code == 0
+      with:
+        path: ~/${{ env.PG_SRC_DIR }}
+        key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}\
+          -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
     - name: Upload config.log
       if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -91,7 +91,6 @@ jobs:
     - name: Checkout lantern
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.ref  }}
         fetch-depth: 0
         submodules: "recursive"
 

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -44,18 +44,6 @@ env:
     log_exe_name=true print_suppressions=false exitcode=27
 
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
-      pg15_latest: ${{ steps.setter.outputs.PG15_LATEST }}
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-        #- name: Read configuration
-        #  id: setter
-        #  run: python .github/gh_config_reader.py
-
   sanitizer:
     # Change the JOB_NAME variable below when changing the name.
     # Don't use the env variable here because the env context is not accessible.
@@ -68,6 +56,9 @@ jobs:
         os: ["ubuntu-22.04"]
         pg: ["15.4"]#["15.4", "16.0"]
     steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update
@@ -159,8 +150,6 @@ jobs:
     - name: Start Postgres
       run: |
         mkdir -p $PG_INSTALL_DIR/data
-        groupadd -r postgres
-        useradd -r -g postgres postgres
         chown -R postgres:postgres $PG_INSTALL_DIR/data
         chown -R postgres:postgres ${{ github.workspace }}/sanitizer
         su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -49,7 +49,6 @@ jobs:
     # Don't use the env variable here because the env context is not accessible.
     name: PG${{ matrix.pg }} Sanitizer ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: config
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -54,10 +54,6 @@ jobs:
       matrix:
         os: ["ubuntu-22.04"]
         pg: ["15.4"]#["15.4", "16.0"]
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update
@@ -149,8 +145,8 @@ jobs:
     - name: Start Postgres
       run: |
         mkdir -p $PG_INSTALL_DIR/data
-        chown -R postgres:postgres $PG_INSTALL_DIR/data
-        chown -R postgres:postgres ${{ github.workspace }}/sanitizer
+        sudo chown -R postgres:postgres $PG_INSTALL_DIR/data
+        sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
         su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
         echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
         echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dev
       - trigger/sanitizer
   pull_request:
     paths: .github/workflows/sanitizer-build-and-test.yaml

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -53,9 +53,9 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
-    - name: Read configuration
-      id: setter
-      run: python .github/gh_config_reader.py
+        #- name: Read configuration
+        #  id: setter
+        #  run: python .github/gh_config_reader.py
 
   sanitizer:
     # Change the JOB_NAME variable below when changing the name.
@@ -67,12 +67,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        pg: ["15.4", "16.0"]
+        pg: ["15.4"]#["15.4", "16.0"]
     steps:
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install wget \
+        sudo apt-get install -y wget \
         curl \
         systemd-coredump \
         build-essential \
@@ -129,13 +129,12 @@ jobs:
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         # Add instrumentation to the Postgres memory contexts. For more details, see
         # https://www.postgresql.org/message-id/CAM-w4HNH7%2BU9jZevpVK7Wr49tkfpWSR6wav0RLYrq0HWuP5cxw%40mail.gmail.com
-        patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation.patch
+        patch -F5 -p1 -d ~/$PG_SRC_DIR < scripts/sanitizers/postgres-asan-instrumentation.patch
         cd ~/$PG_SRC_DIR
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
         make -j$(nproc)
         make -j$(nproc) -C src/test/isolation
-        make -j$(nproc) -C contrib/postgres_fdw
 
     - name: Upload config.log
       if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -153,8 +153,8 @@ jobs:
         #sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
         #getent group postgres || sudo groupadd postgres
         #id -u postgres  &>/dev/null || sudo useradd -g postgres postgres
-        initdb  -A trust -D $PG_INSTALL_DIR/data"
-        postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &"
+        initdb  -A trust -D $PG_INSTALL_DIR/data
+        postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &
 
     - name: make test
       run: |

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -1,9 +1,7 @@
 # Run tests with sanitizers enabled
-# largely copied from https://github.com/timescale/timescaledb/blob/main/.github/workflows/sanitizer-build-and-test.yaml
+# derived from from https://github.com/timescale/timescaledb/blob/main/.github/workflows/sanitizer-build-and-test.yaml
 name: Sanitizer test
 on:
-  schedule:
-    - cron: '0 0 * * 0'
   push:
     branches:
       - main
@@ -12,6 +10,8 @@ on:
     branches:
       - main
     paths: .github/workflows/sanitizer-build-and-test.yaml
+  release:
+    types: [created, edited]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -59,6 +59,13 @@ jobs:
         os: ["ubuntu-22.04"]
         pg: ["11.21", "12.16", "13.2", "14.9", "15.4", "16.0"]
     steps:
+    - name: Enable UBSan if this is a release
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        echo "CFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"" >> $GITHUB_ENV
+        echo "CXXFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"" >> $GITHUB_ENV
+        echo "LDFLAGS=\"-fsanitize=address,undefined\"" >> $GITHUB_ENV
+
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -152,11 +152,11 @@ jobs:
         sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
         #getent group postgres || sudo groupadd postgres
         #id -u postgres  &>/dev/null || sudo useradd -g postgres postgres
-        su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
+        sudo su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
         echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
         echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf
         echo "host    all             all             ::1/128                 trust" >>  ${PGDATA}/pg_hba.conf
-        su -c "$PG_INSTALL_DIR/bin/postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &" postgres
+        sudo su -c "$PG_INSTALL_DIR/bin/postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &" postgres
 
     - name: make test
       run: |

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -19,6 +19,7 @@ on:
 env:
   name: "Sanitizer"
   PG_SRC_DIR: "pgbuild"
+  PG_INSTALL_DIR: ${{ github.workspace }}/pgsql
   extra_packages: "clang-15 llvm-15 llvm-15-dev llvm-15-tools"
   llvm_config: "llvm-config-15"
   CLANG: "clang-15"
@@ -129,7 +130,7 @@ jobs:
         # https://www.postgresql.org/message-id/CAM-w4HNH7%2BU9jZevpVK7Wr49tkfpWSR6wav0RLYrq0HWuP5cxw%40mail.gmail.com
         patch -F5 -p1 -d ~/$PG_SRC_DIR < scripts/sanitizers/postgres-asan-instrumentation.patch
         cd ~/$PG_SRC_DIR
-        ./configure --prefix=/usr/local/pgsql --enable-debug --enable-cassert \
+        ./configure --prefix=$PG_INSTALL_DIR --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
         make -j$(nproc)
         make -j$(nproc) -C contrib/pageinspect
@@ -145,8 +146,8 @@ jobs:
     - name: Install PostgreSQL ${{ matrix.pg }}
       run: |
         make -C ~/$PG_SRC_DIR install
-        echo /usr/local/pgsql/bin >> $GITHUB_PATH
-        /usr/local/pgsql/bin/pg_config --version
+        echo $PG_INSTALL_DIR/bin >> $GITHUB_PATH
+        $PG_INSTALL_DIR/bin/pg_config --version
 
     - name: Build Lantern
       run: |
@@ -157,16 +158,16 @@ jobs:
 
     - name: Start Postgres
       run: |
-        mkdir -p /usr/local/pgsql/data
+        mkdir -p $PG_INSTALL_DIR/data
         groupadd -r postgres
         useradd -r -g postgres postgres
-        chown -R postgres:postgres /usr/local/pgsql/data
+        chown -R postgres:postgres $PG_INSTALL_DIR/data
         chown -R postgres:postgres ${{ github.workspace }}/sanitizer
-        su -c "/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data" postgres
+        su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
         echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
         echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf
         echo "host    all             all             ::1/128                 trust" >>  ${PGDATA}/pg_hba.conf
-        su -c "/usr/local/pgsql/bin/postgres -D /usr/local/pgsql/data >/tmp/postgres.log 2>&1 &" postgres
+        su -c "$PG_INSTALL_DIR/bin/postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &" postgres
 
     - name: make test
       run: |

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -210,7 +210,7 @@ jobs:
           info locals
           bt full
         " 2>&1 | tee stacktrace.log
-        ./scripts/sanitizers/bundle_coredumps.sh
+        ./scripts/sanitizers/bundle_coredump.sh
         grep -C40 "was terminated by signal" postgres.log > postgres-failure.log ||:
 
     - name: Coredumps

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -204,14 +204,14 @@ jobs:
         name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: |
           regression.log
-          postgres.log
 
-    - name: Save PostgreSQL log
-      if: always()
+    - name: Save postgres log
+      if: always() && steps.collectlogs.outputs.regression_diff == 'true'
       uses: actions/upload-artifact@v3
       with:
-        name: PostgreSQL log ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
-        path: /var/log/postgresql/*.log
+        name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: |
+          postgres.log
 
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -2,6 +2,8 @@
 # largely copied from https://github.com/timescale/timescaledb/blob/main/.github/workflows/sanitizer-build-and-test.yaml
 name: Sanitizer test
 on:
+  schedule:
+    - cron: '0 0 * * 0'
   push:
     branches:
       - main
@@ -55,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        pg: ["15.4"]#["15.4", "16.0"]
+        pg: ["11.21", "12.16", "13.2", "14.9", "15.4", "16.0"]
     steps:
     - name: Install Linux Dependencies
       run: |
@@ -89,7 +91,7 @@ jobs:
     - name: Get date for build caching
       id: get-date
       run: |
-        echo "date=$(date +"%d")" >> $GITHUB_OUTPUT
+        echo "date=$(date +"%m-%y")" >> $GITHUB_OUTPUT
 
     # Create a directory for sanitizer logs. This directory is referenced by
     # ASAN_OPTIONS, LSAN_OPTIONS, and UBSAN_OPTIONS

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -54,6 +54,7 @@ jobs:
       matrix:
         os: ["ubuntu-22.04"]
         pg: ["15.4"]#["15.4", "16.0"]
+    steps:
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -19,28 +19,27 @@ on:
 env:
   name: "Sanitizer"
   PG_SRC_DIR: "pgbuild"
-  PG_INSTALL_DIR: "postgresql"
   extra_packages: "clang-15 llvm-15 llvm-15-dev llvm-15-tools"
   llvm_config: "llvm-config-15"
   CLANG: "clang-15"
   CC: "clang-15"
   CXX: "clang-15"
 
-  CFLAGS: "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
-  CXXFLAGS: "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
-  LDFLAGS: "-fsanitize=address,undefined"
+  CFLAGS: "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
+  CXXFLAGS: "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
+  LDFLAGS: "-fsanitize=address"
 
-  ASAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_asan.txt
-    detect_odr_violation=0 log_path=${{ github.workspace }}/sanitizer/sanitizer
+  ASAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/sanitizers/suppressions/suppr_asan.txt
+    detect_odr_violation=0 log_path=${{ github.workspace }}/sanitizer/
     log_exe_name=true print_suppressions=false exitcode=27
     detect_leaks=0 abort_on_error=1
 
-  LSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_leak.txt
-    print_suppressions=0 log_path=${{ github.workspace }}/sanitizer/sanitizer
+  LSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/sanitizers/suppressions/suppr_leak.txt
+    print_suppressions=0 log_path=${{ github.workspace }}/sanitizer/
     log_exe_name=true print_suppressions=false exitcode=27
 
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_ub.txt
-    print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer/sanitizer
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/sanitizers/suppressions/suppr_ub.txt
+    print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer/
     log_exe_name=true print_suppressions=false exitcode=27
 
 jobs:
@@ -130,9 +129,10 @@ jobs:
         # https://www.postgresql.org/message-id/CAM-w4HNH7%2BU9jZevpVK7Wr49tkfpWSR6wav0RLYrq0HWuP5cxw%40mail.gmail.com
         patch -F5 -p1 -d ~/$PG_SRC_DIR < scripts/sanitizers/postgres-asan-instrumentation.patch
         cd ~/$PG_SRC_DIR
-        ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
+        ./configure --prefix=/usr/local/pgsql --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
         make -j$(nproc)
+        make -j$(nproc) -C contrib/pageinspect
         make -j$(nproc) -C src/test/isolation
 
     - name: Upload config.log
@@ -145,8 +145,8 @@ jobs:
     - name: Install PostgreSQL ${{ matrix.pg }}
       run: |
         make -C ~/$PG_SRC_DIR install
-        make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
-        ~/$PG_INSTALL_DIR/bin/pg_config --version
+        echo /usr/local/pgsql/bin >> $GITHUB_PATH
+        /usr/local/pgsql/bin/pg_config --version
 
     - name: Build Lantern
       run: |
@@ -154,6 +154,19 @@ jobs:
         cd lantern_build
         CXXFLAG="" cmake ..
         make install
+
+    - name: Start Postgres
+      run: |
+        mkdir -p /usr/local/pgsql/data
+        groupadd -r postgres
+        useradd -r -g postgres postgres
+        chown -R postgres:postgres /usr/local/pgsql/data
+        chown -R postgres:postgres ${{ github.workspace }}/sanitizer
+        su -c "/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data" postgres
+        echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
+        echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf
+        echo "host    all             all             ::1/128                 trust" >>  ${PGDATA}/pg_hba.conf
+        su -c "/usr/local/pgsql/bin/postgres -D /usr/local/pgsql/data >/tmp/postgres.log 2>&1 &" postgres
 
     - name: make test
       run: |
@@ -165,7 +178,7 @@ jobs:
       id: collectlogs
       run: |
         find /tmp/lantern -name regression.diffs -exec cat {} + > regression.log
-        #find /tmp/lantern -name postmaster.log -exec cat {} + > postgres.log
+        find /tmp/ -name postgres.log -exec cat {} + > postgres.log
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           # wait in case there are in-progress coredumps
           sleep 10
@@ -184,6 +197,7 @@ jobs:
         name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: |
           regression.log
+          postgres.log
 
     - name: Save PostgreSQL log
       if: always()

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -166,7 +166,7 @@ jobs:
       id: collectlogs
       run: |
         find /tmp/lantern -name regression.diffs -exec cat {} + > regression.log
-        find /tmp/ -name postgres.log -exec cat {} + > postgres.log
+        cp /tmp/postgres.log .
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           # wait in case there are in-progress coredumps
           sleep 10

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -1,0 +1,228 @@
+# Run tests with sanitizers enabled
+# largely copied from https://github.com/timescale/timescaledb/blob/main/.github/workflows/sanitizer-build-and-test.yaml
+name: Sanitizer test
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - trigger/sanitizer
+  pull_request:
+    paths: .github/workflows/sanitizer-build-and-test.yaml
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build against llvm sanitizers"
+        required: false
+        default: false
+
+env:
+  name: "Sanitizer"
+  PG_SRC_DIR: "pgbuild"
+  PG_INSTALL_DIR: "postgresql"
+  extra_packages: "clang-15 llvm-15 llvm-15-dev llvm-15-tools"
+  llvm_config: "llvm-config-15"
+  CLANG: "clang-15"
+  CC: "clang-15"
+  CXX: "clang-15"
+
+  CFLAGS: "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
+  CXXFLAGS: "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
+  LDFLAGS: "-fsanitize=address,undefined"
+
+  ASAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_asan.txt
+    detect_odr_violation=0 log_path=${{ github.workspace }}/sanitizer/sanitizer
+    log_exe_name=true print_suppressions=false exitcode=27
+    detect_leaks=0 abort_on_error=1
+
+  LSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_leak.txt
+    print_suppressions=0 log_path=${{ github.workspace }}/sanitizer/sanitizer
+    log_exe_name=true print_suppressions=false exitcode=27
+
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_ub.txt
+    print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer/sanitizer
+    log_exe_name=true print_suppressions=false exitcode=27
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+      pg15_latest: ${{ steps.setter.outputs.PG15_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
+  sanitizer:
+    # Change the JOB_NAME variable below when changing the name.
+    # Don't use the env variable here because the env context is not accessible.
+    name: PG${{ matrix.pg }} Sanitizer ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04"]
+        pg: ["15.4", "16.0"]
+    steps:
+    - name: Install Linux Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install wget \
+        curl \
+        systemd-coredump \
+        build-essential \
+        gdb \
+        make \
+        cmake \
+        pkg-config \
+        flex \
+        bison \
+        libicu-dev \
+        libssl-dev \
+        clang-15 \
+        llvm-15 \
+        llvm-15-dev \
+        llvm-15-tools \
+        libstdc++-12-dev \
+        libstdc++6
+
+    - name: Checkout lantern
+      uses: actions/checkout@v3
+      with:
+        submodules: "recursive"
+
+    # We are going to rebuild Postgres daily, so that it doesn't suddenly break
+    # ages after the original problem.
+    - name: Get date for build caching
+      id: get-date
+      run: |
+        echo "date=$(date +"%d")" >> $GITHUB_OUTPUT
+
+    # Create a directory for sanitizer logs. This directory is referenced by
+    # ASAN_OPTIONS, LSAN_OPTIONS, and UBSAN_OPTIONS
+    - name: Create sanitizer log directory
+      run: |
+        mkdir ${{ github.workspace }}/sanitizer
+
+    # we cache the build directory instead of the install directory here
+    # because extension installation will write files to install directory
+    # leading to a tainted cache
+    - name: Cache PostgreSQL ${{ matrix.pg }}
+      id: cache-postgresql
+      uses: actions/cache@v3
+      with:
+        path: ~/${{ env.PG_SRC_DIR }}
+        key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}\
+          -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
+
+    - name: Build PostgreSQL ${{ matrix.pg }} if not in cache
+      if: steps.cache-postgresql.outputs.cache-hit != 'true'
+      run: |
+        wget -q -O postgresql.tar.bz2 \
+          https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
+        mkdir -p ~/$PG_SRC_DIR
+        tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
+        # Add instrumentation to the Postgres memory contexts. For more details, see
+        # https://www.postgresql.org/message-id/CAM-w4HNH7%2BU9jZevpVK7Wr49tkfpWSR6wav0RLYrq0HWuP5cxw%40mail.gmail.com
+        patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation.patch
+        cd ~/$PG_SRC_DIR
+        ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
+          --with-openssl --without-readline --without-zlib --without-libxml
+        make -j$(nproc)
+        make -j$(nproc) -C src/test/isolation
+        make -j$(nproc) -C contrib/postgres_fdw
+
+    - name: Upload config.log
+      if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: config.log for PostgreSQL ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
+        path: ~/${{ env.PG_SRC_DIR }}/config.log
+
+    - name: Install PostgreSQL ${{ matrix.pg }}
+      run: |
+        make -C ~/$PG_SRC_DIR install
+        make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
+        ~/$PG_INSTALL_DIR/bin/pg_config --version
+
+    - name: Build Lantern
+      run: |
+        mkdir lantern_build
+        cd lantern_build
+        CXXFLAG="" cmake ..
+        make install
+
+    - name: make test
+      run: |
+        cd lantern_build
+        make test
+
+    - name: Show regression diffs
+      if: always()
+      id: collectlogs
+      run: |
+        find /tmp/lantern -name regression.diffs -exec cat {} + > regression.log
+        #find /tmp/lantern -name postmaster.log -exec cat {} + > postgres.log
+        if [[ "${{ runner.os }}" == "Linux" ]] ; then
+          # wait in case there are in-progress coredumps
+          sleep 10
+          if coredumpctl -q list >/dev/null; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
+          # print OOM killer information
+          sudo journalctl --system -q --facility=kern --grep "Killed process" || true
+        fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
+        #grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
+        cat regression.log
+
+    - name: Save regression diffs
+      if: always() && steps.collectlogs.outputs.regression_diff == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: |
+          regression.log
+
+    - name: Save PostgreSQL log
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: PostgreSQL log ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: /var/log/postgresql/*.log
+
+    - name: Stack trace
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      run: |
+        sudo coredumpctl gdb <<<"
+          set verbose on
+          set trace-commands on
+          show debug-file-directory
+          printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          frame function ExceptionalCondition
+          printf "'"'"condition = '%s'\n"'"'", conditionName
+          up 1
+          l
+          info args
+          info locals
+          bt full
+        " 2>&1 | tee stacktrace.log
+        ./scripts/sanitizers/bundle_coredumps.sh
+        grep -C40 "was terminated by signal" postgres.log > postgres-failure.log ||:
+
+    - name: Coredumps
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Coredumps ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: coredumps
+
+    - name: sanitizer logs
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: sanitizer logs ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: ${{ github.workspace }}/sanitizer

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -136,6 +136,7 @@ jobs:
       run: |
         make -C ~/$PG_SRC_DIR install
         echo $PG_INSTALL_DIR/bin >> $GITHUB_PATH
+        sudo chown -R 755 $PG_INSTALL_DIR/bin
         $PG_INSTALL_DIR/bin/pg_config --version
 
     - name: Build Lantern

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -7,6 +7,8 @@ on:
       - main
       - trigger/sanitizer
   pull_request:
+    branches:
+      - main
     paths: .github/workflows/sanitizer-build-and-test.yaml
   workflow_dispatch:
     inputs:
@@ -148,6 +150,8 @@ jobs:
         mkdir -p $PG_INSTALL_DIR/data
         sudo chown -R postgres:postgres $PG_INSTALL_DIR/data
         sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
+        #getent group postgres || sudo groupadd postgres
+        #id -u postgres  &>/dev/null || sudo useradd -g postgres postgres
         su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
         echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
         echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -62,8 +62,8 @@ jobs:
     - name: Enable UBSan if this is a release
       if: ${{ github.event_name == 'release' }}
       run: |
-        echo "CFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"" >> $GITHUB_ENV
-        echo "CXXFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"" >> $GITHUB_ENV
+        echo "CFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -O0 -fno-inline-functions"" >> $GITHUB_ENV
+        echo "CXXFLAGS=\"\-g -fsanitize=address,undefined -fno-omit-frame-pointer -O0 -fno-inline-functions"" >> $GITHUB_ENV
         echo "LDFLAGS=\"-fsanitize=address,undefined\"" >> $GITHUB_ENV
 
     - name: Install Linux Dependencies
@@ -91,6 +91,8 @@ jobs:
     - name: Checkout lantern
       uses: actions/checkout@v3
       with:
+        ref: ${{ github.ref  }}
+        fetch-depth: 0
         submodules: "recursive"
 
     # We are going to rebuild Postgres daily, so that it doesn't suddenly break
@@ -209,7 +211,7 @@ jobs:
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
       uses: actions/upload-artifact@v3
       with:
-        name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        name: Postgres log ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: |
           postgres.log
 

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -149,15 +149,12 @@ jobs:
     - name: Start Postgres
       run: |
         mkdir -p $PG_INSTALL_DIR/data
-        sudo chown -R postgres:postgres $PG_INSTALL_DIR/data
-        sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
+        #sudo chown -R postgres:postgres $PG_INSTALL_DIR/data
+        #sudo chown -R postgres:postgres ${{ github.workspace }}/sanitizer
         #getent group postgres || sudo groupadd postgres
         #id -u postgres  &>/dev/null || sudo useradd -g postgres postgres
-        sudo su -c "$PG_INSTALL_DIR/bin/initdb -D $PG_INSTALL_DIR/data" postgres
-        echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf
-        echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf
-        echo "host    all             all             ::1/128                 trust" >>  ${PGDATA}/pg_hba.conf
-        sudo su -c "$PG_INSTALL_DIR/bin/postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &" postgres
+        initdb  -A trust -D $PG_INSTALL_DIR/data"
+        postgres -D $PG_INSTALL_DIR/data >/tmp/postgres.log 2>&1 &"
 
     - name: make test
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test/tmp_output/
 .DS_Store
 build
 data
+sanitizer
 .vscode/
 .devcontainer/
 .cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,15 +119,24 @@ set_target_properties(
 # needed to make sure cmake does not add libstdc++ to the linker command when an
 # external cpp library is added more at`
 # https://cmake-developers.cmake.narkive.com/JnbrDyGT/setting-linker-language-still-adds-lstdc
-
 if(NOT APPLE)
-  # apples does not understand -static-libstdc++ used in usearch to bundle libstdc++ with the
-  # created archive.
-  # so, on apple we dynamically link to the c++ runtime
-  # todo:: find a way to statically link the c++ runtime on mac
-  set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
-  set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
+  # clang handles static libstdc++ differently than gcc
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    find_library(STATIC_LIBSTDCPP NAMES libstdc++.a PATHS ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
+
+    if(STATIC_LIBSTDCPP)
+        set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES};${STATIC_LIBSTDCPP}")
+    endif()
+  else()
+    # apples does not understand -static-libstdc++ used in usearch to bundle libstdc++ with the
+    # created archive.
+    # so, on apple we dynamically link to the c++ runtime
+    # todo:: find a way to statically link the c++ runtime on mac
+    set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+    set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
+  endif()
 endif()
+
 set_target_properties(lantern PROPERTIES LINKER_LANGUAGE C)
 
 target_include_directories(lantern PRIVATE "./third_party/usearch/c")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,10 @@ Below is a short recording demonstrating the use of `livedebug.py`:
 
 [![asciicast](https://asciinema.org/a/jTsbWdOcTvUl4iAJlAw3Cszbt.svg)](https://asciinema.org/a/jTsbWdOcTvUl4iAJlAw3Cszbt)
 
+## Running sanitizers
+
+To ensure that code is safe, pull requests are tested using google's [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer). Additionally [UBSan](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) is run against releases. A [docker container](scripts/sanitizers/Dockerfile) is provided for testing changes locally. it can be invoked by running the script `scripts/sanitizers/run_sanitizers.sh`. **Please note that this script must be run in the root directory of the lantern repository**. By default it will build `postgres 15.4` and run tests against it instrumented only with AddressSanitizer. If you would like to run UBSan you can pass the `-u` flag. If you wish to test against a specific version you can use the `-v` flag specifying a specific version, e.g. `scripts/sanitizers/run_sanitizers.sh -u -v11.21`
+
 ## Adding/modifying LanternDB's SQL interface
 
 When modifying the SQL interface, you add relevant SQL logic under `sql/`. In addition, you add an update script under `sql/updates`, in a file named `[CURRENT_VERSION]--latest.sql`. You should create this file if it does not exist.

--- a/scripts/sanitizers/Dockerfile
+++ b/scripts/sanitizers/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && \
     llvm-15 \
     llvm-15-dev \
     llvm-15-tools \
-    libstdc++-12-dev \
     libstdc++6
 
 RUN wget -q -O postgresql.tar.bz2 \
@@ -38,12 +37,12 @@ RUN patch -F5 -p1 -d . < /lantern/scripts/sanitizers/postgres-asan-instrumentati
 RUN groupadd -r postgres --gid=999 && \
      useradd -r -g postgres --uid=999 postgres 
 
-#ENV LLVM_CONFIG "llvm-config-15"
+ENV LLVM_CONFIG "llvm-config-15"
 ENV CC "clang-15"
 ENV CXX "clang-15"
-ENV CFLAGS "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
-ENV CXXFLAGS "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
-ENV LDFLAGS "-fsanitize=address,undefined"
+ENV CFLAGS "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV CXXFLAGS "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV LDFLAGS "-fsanitize=address"
 
 RUN ./configure --prefix=/usr/local/pgsql --enable-debug --enable-cassert \
     --with-openssl --without-readline --without-zlib --without-libxml && \
@@ -87,7 +86,7 @@ COPY . .
 RUN rm -rf build && \
     mkdir build && \
     cd build && \
-    CXXFLAGS="" cmake -DCMAKE_BUILD_TYPE=Debug .. && \
+    CXXFLAGS="" cmake -DCMAKE_BUILD_TYPE=Debug -DUSEARCH_NO_MARCH_NATIVE=ON .. && \
     make install
 
 USER postgres

--- a/scripts/sanitizers/Dockerfile
+++ b/scripts/sanitizers/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bookworm
 
 ARG VERSION=15.4
 ARG PGVECTOR_VERSION=0.5.0
+ARG UBSAN=
 
 WORKDIR /lantern
 # This requires the docker command be run in the lantern base director
@@ -40,9 +41,9 @@ RUN groupadd -r postgres --gid=999 && \
 ENV LLVM_CONFIG "llvm-config-15"
 ENV CC "clang-15"
 ENV CXX "clang-15"
-ENV CFLAGS "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
-ENV CXXFLAGS "-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions"
-ENV LDFLAGS "-fsanitize=address"
+ENV CFLAGS "-g -fsanitize=address${UBSAN} -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV CXXFLAGS "-g -fsanitize=address${UBSAN} -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV LDFLAGS "-fsanitize=address${UBSAN}"
 
 RUN ./configure --prefix=/usr/local/pgsql --enable-debug --enable-cassert \
     --with-openssl --without-readline --without-zlib --without-libxml && \
@@ -86,7 +87,7 @@ COPY . .
 RUN rm -rf build && \
     mkdir build && \
     cd build && \
-    CXXFLAGS="" cmake -DCMAKE_BUILD_TYPE=Debug -DUSEARCH_NO_MARCH_NATIVE=ON .. && \
+    CXXFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Og -fno-inline-functions" cmake .. && \
     make install
 
 USER postgres

--- a/scripts/sanitizers/Dockerfile
+++ b/scripts/sanitizers/Dockerfile
@@ -1,0 +1,99 @@
+FROM debian:bookworm
+
+ARG VERSION=15.4
+ARG PGVECTOR_VERSION=0.5.0
+
+WORKDIR /lantern
+# This requires the docker command be run in the lantern base director
+COPY scripts scripts
+
+WORKDIR pg_build
+
+RUN apt-get update && \
+    apt-mark hold locales && \
+    apt-get install -y \
+    wget \
+    curl \
+    build-essential \
+    make \
+    cmake \
+    pkg-config \
+    flex \
+    bison \
+    libicu-dev \
+    libssl-dev \
+    clang-15 \
+    llvm-15 \
+    llvm-15-dev \
+    llvm-15-tools \
+    libstdc++-12-dev \
+    libstdc++6
+
+RUN wget -q -O postgresql.tar.bz2 \
+     https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.bz2 && \
+     tar --extract --file postgresql.tar.bz2 --directory . --strip-components 1
+
+RUN patch -F5 -p1 -d . < /lantern/scripts/sanitizers/postgres-asan-instrumentation.patch
+
+RUN groupadd -r postgres --gid=999 && \
+     useradd -r -g postgres --uid=999 postgres 
+
+#ENV LLVM_CONFIG "llvm-config-15"
+ENV CC "clang-15"
+ENV CXX "clang-15"
+ENV CFLAGS "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV CXXFLAGS "-g -fsanitize=address,undefined -fno-omit-frame-pointer -Og -fno-inline-functions"
+ENV LDFLAGS "-fsanitize=address,undefined"
+
+RUN ./configure --prefix=/usr/local/pgsql --enable-debug --enable-cassert \
+    --with-openssl --without-readline --without-zlib --without-libxml && \
+    make -j$(nproc) && \
+    make -j$(nproc) -C src/test/isolation && \
+    make install
+
+ENV PATH="/usr/local/pgsql/bin:${PATH}"
+ENV LD_LIBRARY_PATH=:/usr/local/pgsql/lib
+ENV PGDATA=/var/lib/postgresql/data
+RUN mkdir -p ${PGDATA} && \
+    chown -R postgres:postgres ${PGDATA} && \
+    chmod 777 ${PGDATA}
+
+WORKDIR /lantern
+
+RUN mkdir /lantern/sanitizer && \
+    chown -R postgres:postgres /lantern && \
+    chmod 777 /lantern/sanitizer
+
+ENV ASAN_OPTIONS suppressions=/lantern/scripts/sanitizers/suppressions/suppr_asan.txt \
+  detect_odr_violation=0 log_path=/lantern/sanitizer/ \
+  log_exe_name=true print_suppressions=false exitcode=27 \
+  detect_leaks=0 abort_on_error=1
+
+ENV LSAN_OPTIONS suppressions=/lantern/scripts/sanitizers/suppressions/suppr_leak.txt \
+  print_suppressions=0 log_path=/lantern/sanitizer/ \
+  log_exe_name=true print_suppressions=false exitcode=27
+
+ENV UBSAN_OPTIONS suppressions=/lantern/scripts/sanitizers/suppressions/suppr_ub.txt \
+  print_stacktrace=1 halt_on_error=1 log_path=/lantern/sanitizer/ \
+  log_exe_name=true print_suppressions=false exitcode=27
+
+RUN wget -O pgvector.tar.gz https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz && \
+    tar xf pgvector.tar.gz && \
+    cd pgvector-${PGVECTOR_VERSION} && \
+    make && make install
+
+COPY . .
+
+RUN rm -rf build && \
+    mkdir build && \
+    cd build && \
+    CXXFLAGS="" cmake -DCMAKE_BUILD_TYPE=Debug .. && \
+    make install
+
+USER postgres
+RUN initdb -D ${PGDATA} && \
+    echo "local   all             all                                     trust" >  ${PGDATA}/pg_hba.conf && \
+    echo "host    all             all             127.0.0.1/32            trust" >>  ${PGDATA}/pg_hba.conf && \
+    echo "host    all             all             ::1/128                 trust" >>  ${PGDATA}/pg_hba.conf
+
+CMD ["postgres", "-D", "/var/lib/postgresql/data"]

--- a/scripts/sanitizers/bundle_coredump.sh
+++ b/scripts/sanitizers/bundle_coredump.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TARGET=coredumps
+COREDUMP_DIR=/var/lib/systemd/coredump
+
+set -e
+
+mkdir -p "$TARGET"
+
+# get information from gdb
+info=$(echo "info sharedlibrary" | coredumpctl gdb)
+
+executable=$(echo "$info" | grep Executable | sed -e 's!^[^/]\+!!')
+
+cp "$executable" "$TARGET"
+cp ${COREDUMP_DIR}/* "$TARGET"
+
+# copy libraries extracted from gdb info
+echo "$info" | grep '^0x' | sed -e 's!^[^/]\+!!' | xargs -ILIB cp "LIB" "$TARGET"

--- a/scripts/sanitizers/bundle_coredump.sh
+++ b/scripts/sanitizers/bundle_coredump.sh
@@ -1,3 +1,4 @@
+# This file was copied from timescaledb
 #!/bin/bash
 
 TARGET=coredumps

--- a/scripts/sanitizers/postgres-asan-instrumentation.patch
+++ b/scripts/sanitizers/postgres-asan-instrumentation.patch
@@ -1,0 +1,53 @@
+diff --git a/src/backend/tcop/postgres.c b/src/backend/tcop/postgres.c
+index 2c50575b37..11b6c688c7 100644
+--- a/src/backend/tcop/postgres.c
++++ b/src/backend/tcop/postgres.c
+@@ -3492,6 +4476,12 @@ check_stack_depth(void)
+ bool
+ stack_is_too_deep(void)
+ {
++	/*
++	 * Pointer arithmetics to determine stack depth doesn't work under
++	 * AddressSanitizer.
++	 */
++	return false;
++
+ 	char		stack_top_loc;
+ 	long		stack_depth;
+ 
+diff --git a/src/include/utils/memdebug.h b/src/include/utils/memdebug.h
+index e88b4c6e8e..4ccbbf0146 100644
+--- a/src/include/utils/memdebug.h
++++ b/src/include/utils/memdebug.h
+@@ -19,6 +19,31 @@
+ 
+ #ifdef USE_VALGRIND
+ #include <valgrind/memcheck.h>
++
++#elif __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
++
++#include <sanitizer/asan_interface.h>
++
++#define VALGRIND_MAKE_MEM_DEFINED(addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MAKE_MEM_NOACCESS(addr, size) \
++ ASAN_POISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MAKE_MEM_UNDEFINED(addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MEMPOOL_ALLOC(context, addr, size) \
++ ASAN_UNPOISON_MEMORY_REGION(addr, size)
++
++#define VALGRIND_MEMPOOL_FREE(context, addr) \
++ ASAN_POISON_MEMORY_REGION(addr, 1 /* Length unknown, poison first byte. */)
++
++#define VALGRIND_CHECK_MEM_IS_DEFINED(addr, size) do {} while (0)
++#define VALGRIND_CREATE_MEMPOOL(context, redzones, zeroed) do {} while (0)
++#define VALGRIND_DESTROY_MEMPOOL(context) do {} while (0)
++#define VALGRIND_MEMPOOL_CHANGE(context, optr, nptr, size) do {} while (0)
++
+ #else
+ #define VALGRIND_CHECK_MEM_IS_DEFINED(addr, size)			do {} while (0)
+ #define VALGRIND_CREATE_MEMPOOL(context, redzones, zeroed)	do {} while (0)

--- a/scripts/sanitizers/run_sanitizers.sh
+++ b/scripts/sanitizers/run_sanitizers.sh
@@ -3,9 +3,19 @@ if [ ! -f src/hnsw.c ]; then
       echo "script must be run in lantern root directory"
       exit 1
 fi
-docker build -t lantern-san -f scripts/sanitizers/Dockerfile .
-docker run lantern-san
 
-docker exec -i -u postgres -w /lantern/build lantern-san /bin/bash <<EOF
+mkdir -p sanitizer
+
+docker build -t lantern-san -f scripts/sanitizers/Dockerfile .
+
+docker run --rm -d -v $(pwd)/sanitizer:/lantern/sanitizer --name lantern-sanitizers lantern-san
+
+docker exec -i -u root lantern-sanitizers /bin/bash <<EOF
+chown -R postgres:postgres /lantern/sanitizer
+EOF
+
+docker exec -i -u postgres -w /lantern/build lantern-sanitizers /bin/bash <<EOF
 make test
 EOF
+
+docker kill lantern-sanitizers

--- a/scripts/sanitizers/run_sanitizers.sh
+++ b/scripts/sanitizers/run_sanitizers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if [ ! -f src/hnsw.c ]; then
+      echo "script must be run in lantern root directory"
+      exit 1
+fi
+docker build -t lantern-san -f scripts/sanitizers/Dockerfile .
+docker run lantern-san
+
+docker exec -i -u postgres -w /lantern/build lantern-san /bin/bash <<EOF
+make test
+EOF

--- a/scripts/sanitizers/run_sanitizers.sh
+++ b/scripts/sanitizers/run_sanitizers.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
-u_flag=''
+u_flag=""
+v_flag=""
 if [ ! -f src/hnsw.c ]; then
       echo "script must be run in lantern root directory"
       exit 1
 fi
 
 function print_usage {
-    printf "This script takes 1 option '-u' to run the container with ubsan enabled. This may take a long time, expect testing take about 30m\n"
+    printf "FLAGS:
+    '-u' | run the container with ubsan enabled. This may take a long time, expect testing take about 30m
+    '-v <version>' | the version of postgres you wish to test against, by default 15.4. Must include minor version\n"
 }
 
-while getopts 'u' flag; do
+while getopts ':uv:' flag; do
   case "${flag}" in
-    u) u_flag='true' ;;
+    u) u_flag="true" ;;
+    v) v_flag="$OPTARG" ;;
     *) print_usage
        exit 1 ;;
   esac
@@ -25,14 +29,25 @@ trap kill_docker EXIT
 
 mkdir -p sanitizer
 
-CONTAINER=''
-if [[ "$u_flag" == "true" ]]; then
-    docker build -t lantern-san-ub -f scripts/sanitizers/Dockerfile --build-arg="UBSAN=,undefined" .
-    CONTAINER='lantern-san-ub'
-else
-    docker build -t lantern-san -f scripts/sanitizers/Dockerfile .
-    CONTAINER='lantern-san'
+CONTAINER=""
+ARGS=""
+if [[ ! -z $v_flag ]]; then
+    if [[ $v_flag =~ [0-9]{2}\.[0-9]{1,2} ]]; then
+        CONTAINER="-$v_flag"
+        ARGS="--build-arg VERSION=$v_flag"
+    else
+        echo "please specify a valid version"
+        exit 1
+    fi
 fi
+if [[ "$u_flag" == "true" ]]; then
+    ARGS="$ARGS --build-arg UBSAN=,undefined"
+    CONTAINER="lantern-san-ub$CONTAINER"
+else
+    CONTAINER="lantern-san$CONTAINER"
+fi
+
+docker build -t $CONTAINER -f scripts/sanitizers/Dockerfile $ARGS .
 
 docker run --rm -d -v $(pwd)/sanitizer:/lantern/sanitizer --name lantern-sanitizers $CONTAINER
 

--- a/scripts/sanitizers/run_sanitizers.sh
+++ b/scripts/sanitizers/run_sanitizers.sh
@@ -8,6 +8,12 @@ mkdir -p sanitizer
 
 docker build -t lantern-san -f scripts/sanitizers/Dockerfile .
 
+function kill-docker {
+    docker kill lantern-sanitizers
+}
+
+trap kill-docker EXIT
+
 docker run --rm -d -v $(pwd)/sanitizer:/lantern/sanitizer --name lantern-sanitizers lantern-san
 
 docker exec -i -u root lantern-sanitizers /bin/bash <<EOF
@@ -16,6 +22,5 @@ EOF
 
 docker exec -i -u postgres -w /lantern/build lantern-sanitizers /bin/bash <<EOF
 make test
+cp /tmp/lantern/tmp_output/results/*.out /lantern/sanitizer
 EOF
-
-docker kill lantern-sanitizers

--- a/scripts/sanitizers/suppressions/README.md
+++ b/scripts/sanitizers/suppressions/README.md
@@ -1,0 +1,10 @@
+# Suppressions for Clang Sanitizers #
+
+This folder contains [supression files](https://clang.llvm.org/docs/SanitizerSpecialCaseList.html) for
+running timescale using Clang's [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
+and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), which
+we use as part of timescale's regission suite. There are a few places OSs have UB and where postgres
+has benign memory leaks, in order to run these sanitizers, we suppress these warning.
+
+For ease of use, we provide a script in [/scripts/test_sanitizers.sh] to run our regression tests with
+sanitizers enabled.

--- a/scripts/sanitizers/suppressions/README.md
+++ b/scripts/sanitizers/suppressions/README.md
@@ -1,10 +1,7 @@
 # Suppressions for Clang Sanitizers #
 
 This folder contains [supression files](https://clang.llvm.org/docs/SanitizerSpecialCaseList.html) for
-running timescale using Clang's [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
-and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), which
-we use as part of timescale's regission suite. There are a few places OSs have UB and where postgres
-has benign memory leaks, in order to run these sanitizers, we suppress these warning.
+running lantern using Clang's [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
+and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), taken from timescale's regression suite. 
 
-For ease of use, we provide a script in [/scripts/test_sanitizers.sh] to run our regression tests with
-sanitizers enabled.
+There are a few places system libraries have UB and where postgres has benign memory leaks, in order to run these sanitizers, we suppress these warning.

--- a/scripts/sanitizers/suppressions/suppr_asan.txt
+++ b/scripts/sanitizers/suppressions/suppr_asan.txt
@@ -1,0 +1,2 @@
+#suppress getaddrinfo due to internal error on macos
+interceptor_via_fun:getaddrinfo

--- a/scripts/sanitizers/suppressions/suppr_leak.txt
+++ b/scripts/sanitizers/suppressions/suppr_leak.txt
@@ -1,0 +1,33 @@
+leak:save_ps_display_args
+leak:psql/startup.c
+#don't care about the frontend leaks
+leak:fe_memutils.c
+leak:fe-connect.c
+leak:fe-exec.c
+leak:initdb.c
+#annoingly have to supress strdup because it leaks in PostmasterMain -D option
+leak:strdup
+leak:ProcessConfigFileInternal
+leak:internal_load_library
+
+leak:pg_timezone_abbrev_initialize
+leak:check_timezone_abbreviations
+leak:check_session_authorization
+leak:InitializeGUCOptions
+leak:CheckMyDatabase
+
+
+#pg_dump
+leak:getSchemaData
+leak:dumpDumpableObject
+
+#should live as long as the process
+leak:ShmemInitHash
+
+#test only functions
+leak:deserialize_test_parameters
+leak:ts_params_get
+leak:test_job_dispatcher
+
+#openssl
+leak:CRYPTO_zalloc

--- a/scripts/sanitizers/suppressions/suppr_ub.txt
+++ b/scripts/sanitizers/suppressions/suppr_ub.txt
@@ -1,0 +1,26 @@
+alignment:pg_comp_crc32c_sse42
+alignment:array_cmp
+alignment:array_iter_setup
+alignment:array_out
+alignment:array_unnest
+alignment:array_eq
+alignment:AllocSetCheck
+nonnull-attribute:TransactionIdSetPageStatus
+nonnull-attribute:SerializeTransactionState
+nonnull-attribute:initscan
+nonnull-attribute:SetTransactionSnapshot
+nonnull-attribute:shm_mq_receive
+#care, gcc cannot parse the path, only the filename
+nonnull-attribute:*/src/fe_utils/print.c
+nonnull-attribute:print_aligned_text
+#PG13.3-copyfuncs.c:2374:2: runtime error: null pointer passed as argument 2, which is declared to never be null
+nonnull-attribute:_copyAppendRelInfo
+#PG13.3-copyfuncs.c:1190:2: runtime error: null pointer passed as argument 2, which is declared to never be null
+nonnull-attribute:_copyLimit
+nonnull-attribute:*/src/backend/nodes/copyfuncs.c
+#division by 0, looks like a real postgres ug
+float-divide-by-zero:_bt_vacuum_needs_cleanup
+
+# It complains about casting -nan to int in histogram_test.sql. It is in the
+# postgres code and doesn't lead to bugs, because it is caught by a check later.
+float-cast-overflow:width_bucket_float8

--- a/scripts/sanitizers/suppressions/suppr_ub.txt
+++ b/scripts/sanitizers/suppressions/suppr_ub.txt
@@ -25,5 +25,5 @@ float-divide-by-zero:_bt_vacuum_needs_cleanup
 # postgres code and doesn't lead to bugs, because it is caught by a check later.
 float-cast-overflow:width_bucket_float8
 
-#todo try IndexNextWithReorder "load of value 127, which is not a valid value for type 'bool'"
-undefined:*/src/backend/executor/nodeIndexscan.c
+# a bool gets set to an int idk what's wrong
+bool:IndexNextWithReorder

--- a/scripts/sanitizers/suppressions/suppr_ub.txt
+++ b/scripts/sanitizers/suppressions/suppr_ub.txt
@@ -24,3 +24,6 @@ float-divide-by-zero:_bt_vacuum_needs_cleanup
 # It complains about casting -nan to int in histogram_test.sql. It is in the
 # postgres code and doesn't lead to bugs, because it is caught by a check later.
 float-cast-overflow:width_bucket_float8
+
+#todo try IndexNextWithReorder "load of value 127, which is not a valid value for type 'bool'"
+undefined:*/src/backend/executor/nodeIndexscan.c

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -544,8 +544,9 @@ BlockNumber getDataBlockNumber(RetrieverCtx *ctx, int id, bool add_to_extra_dirt
     // clang-format on
 #endif
 
-    union voidblockno {
-        void *ptr;
+    union voidblockno
+    {
+        void       *ptr;
         BlockNumber blockno;
     } blockno_from_cache_p;
     blockno_from_cache_p.ptr = cache_get_item(cache, &id);

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -226,7 +226,7 @@ void _PG_init(void)
                             "Valid values are in range [1, 400]",
                             &ldb_hnsw_ef_search,
                             USEARCH_SEARCH_EF_INVALID_VALUE,
-                            1,
+                            USEARCH_SEARCH_EF_INVALID_VALUE,
                             HNSW_MAX_EF,
                             PGC_USERSET,
                             0,

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -48,6 +48,8 @@ void ldb_wal_retriever_area_reset(RetrieverCtx *ctx, HnswIndexHeaderPage *header
     }
     dlist_init(&ctx->takenbuffers);
 
+    fa_cache_init(&ctx->fa_cache);
+
     assert(ctx->header_page_under_wal == header_page_under_wal);
     ctx->header_page_under_wal = header_page_under_wal;
 }

--- a/test/expected/hnsw_dist_func.out
+++ b/test/expected/hnsw_dist_func.out
@@ -104,24 +104,24 @@ SELECT ARRAY_AGG(id ORDER BY id), ROUND(hamming_dist(v, '{0,1,0}')::numeric, 2) 
 (4 rows)
 
 -- Verify that the indexes is being used
-EXPLAIN SELECT id FROM small_world_l2 ORDER BY v <-> '{0,1,0}';
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Index Scan using small_world_l2_v_idx on small_world_l2  (cost=0.00..60.05 rows=1070 width=20)
+EXPLAIN (COSTS false) SELECT id FROM small_world_l2 ORDER BY v <-> '{0,1,0}';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Index Scan using small_world_l2_v_idx on small_world_l2
    Order By: (v <-> '{0,1,0}'::real[])
 (2 rows)
 
-EXPLAIN SELECT id FROM small_world_cos ORDER BY v <-> '{0,1,0}';
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Index Scan using small_world_cos_v_idx on small_world_cos  (cost=0.00..60.05 rows=1070 width=20)
+EXPLAIN (COSTS false) SELECT id FROM small_world_cos ORDER BY v <-> '{0,1,0}';
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Index Scan using small_world_cos_v_idx on small_world_cos
    Order By: (v <-> '{0,1,0}'::real[])
 (2 rows)
 
-EXPLAIN SELECT id FROM small_world_ham ORDER BY v <-> '{0,1,0}';
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Index Scan using small_world_ham_v_idx on small_world_ham  (cost=0.00..60.05 rows=1070 width=20)
+EXPLAIN (COSTS false) SELECT id FROM small_world_ham ORDER BY v <-> '{0,1,0}';
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Index Scan using small_world_ham_v_idx on small_world_ham
    Order By: (v <-> '{0,1,0}'::integer[])
 (2 rows)
 

--- a/test/expected/hnsw_ef_search.out
+++ b/test/expected/hnsw_ef_search.out
@@ -23,11 +23,10 @@ INSERT INTO sift_base1k (id, v) VALUES
 -- Validate error on invalid ef_search values
 \set ON_ERROR_STOP off
 SET lantern_hnsw.ef_search = -1;
-ERROR:  -1 is outside the valid range for parameter "lantern_hnsw.ef_search" (1 .. 400)
+ERROR:  -1 is outside the valid range for parameter "lantern_hnsw.ef_search" (0 .. 400)
 SET lantern_hnsw.ef_search = 0;
-ERROR:  0 is outside the valid range for parameter "lantern_hnsw.ef_search" (1 .. 400)
 SET lantern_hnsw.ef_search = 401;
-ERROR:  401 is outside the valid range for parameter "lantern_hnsw.ef_search" (1 .. 400)
+ERROR:  401 is outside the valid range for parameter "lantern_hnsw.ef_search" (0 .. 400)
 \set ON_ERROR_STOP on
 -- Repeat the same query while varying ef parameter
 -- NOTE: it is not entirely known if the results of these are deterministic

--- a/test/sql/hnsw_dist_func.sql
+++ b/test/sql/hnsw_dist_func.sql
@@ -29,9 +29,9 @@ SELECT ARRAY_AGG(id ORDER BY id), ROUND(cos_dist(v, '{0,1,0}')::numeric, 2) FROM
 SELECT ARRAY_AGG(id ORDER BY id), ROUND(hamming_dist(v, '{0,1,0}')::numeric, 2) FROM small_world_ham GROUP BY 2 ORDER BY 2;
 
 -- Verify that the indexes is being used
-EXPLAIN SELECT id FROM small_world_l2 ORDER BY v <-> '{0,1,0}';
-EXPLAIN SELECT id FROM small_world_cos ORDER BY v <-> '{0,1,0}';
-EXPLAIN SELECT id FROM small_world_ham ORDER BY v <-> '{0,1,0}';
+EXPLAIN (COSTS false) SELECT id FROM small_world_l2 ORDER BY v <-> '{0,1,0}';
+EXPLAIN (COSTS false) SELECT id FROM small_world_cos ORDER BY v <-> '{0,1,0}';
+EXPLAIN (COSTS false) SELECT id FROM small_world_ham ORDER BY v <-> '{0,1,0}';
 
 \set ON_ERROR_STOP off
 


### PR DESCRIPTION
This adds a github action to run against ASAN when someone pushes to main. There's likely a more appropriate trigger, though considering it's fairly time consuming it may not be worth running on every PR. It should be easy to include UBSan too, however there is UB in postgres' index scan function and I was unable to make ubsan suppress this so for the time being it's disabled. There's a docker container as well that can be invoked using the associated script to test locally. Running ` scripts/sanitizers/run_sanitizers.sh` in the project root will create a directory called `sanitizer` that contains the asan logs. This will be owned by uid 999 so you'll have to chown it. This will likely need some revision, but I wanted to get some eyes on this and test out the github workflow. @var77 if you have any feedback let me know, I recall you had done a lot of work on the other actions

ASan detects a use after free in `getDataBlockNumber` in a couple of tests. I haven't figured out the source. If anyone else is interested in this let me know and I can send along logs and details for recreating it. An example is shown below. It can also trigger in the immutable retriever from gettuple, but I think the insert case might be more telling since the entirety of aminsert nominally runs in a single memory context that is deleted at the end of the access method. 
```
==postgres==420==ERROR: AddressSanitizer: use-after-poison on address 0x7fa40dea7b08 at pc 0x7fa415c8cfdb bp 0x7ffe1c99dab0 sp 0x7ffe1c99daa8
READ of size 4 at 0x7fa40dea7b08 thread T0
    #0 0x7fa415c8cfda in getDataBlockNumber /lantern/src/hnsw/external_index.c:549:16
    #1 0x7fa415c8d890 in ldb_wal_index_node_retriever_mut /lantern/src/hnsw/external_index.c:660:37
    ... absolutely disgusting C++ call stack
    #14 0x7fa415c9586b in usearch_add_external /lantern/third_party/usearch/c/lib.cpp:260:27
    #15 0x7fa415c8f4c6 in ldb_aminsert /lantern/src/hnsw/insert.c:169:5
```
It's not clear exactly what conditions cause this. It reads as if the block cache needs to be cleared at some point, but it's unclear why/where the memory is being released. One test fails scanning an index created from a file and the other fails inserting rows into an empty index. Unfortunately postgres' memory management system necessitates manually poisoning memory which means ASan doesn't log information about where it was freed. The order of operations is probably to set a watchpoint in the shadow memory and use this to determine when memory is poisoned. I made an attempt at this but was left somewhat confused
