### PR TITLE
Figuring out why tests fail on main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,9 @@ jobs:
           sudo pip install GitPython &&\
           # Start postgres
           sudo su postgres -c "PG_VERSION=$PG_VERSION RUN_TESTS=0 ./ci/scripts/run-tests-linux.sh" && \
-          sudo su -c "PG_VERSION=$PG_VERSION python3 ./scripts/test_updates.py -U postgres"
+          sudo su -c "PG_VERSION=$PG_VERSION python3 ./scripts/test_updates.py -U postgres" &&\
+          echo "Done with updates"
+
         env:
           PG_VERSION: ${{ matrix.postgres }}
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # fetch-depth ensures all tags are present on the repo so we can run update tests successfully
+          fetch-depth: 0
           submodules: "recursive"
       - name: Build
         id: build

--- a/scripts/test_updates.py
+++ b/scripts/test_updates.py
@@ -14,7 +14,6 @@ def update_from_tag(from_version: str, to_version: str):
     repo = git.Repo(search_parent_directories=True)
     sha_before = repo.head.object.hexsha
     repo.remotes[0].fetch()
-
     repo.git.checkout(from_tag)
     sha_after = repo.head.object.hexsha
     print("sha_after", sha_after)

--- a/scripts/test_updates.py
+++ b/scripts/test_updates.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     to_tag = args.to_tag
     if from_tag and to_tag:
         update_from_tag(from_tag, to_tag)
+        exit(0)
 
     if from_tag or to_tag:
         print("Must specify both or neither from_tag and to_tag")
@@ -71,7 +72,7 @@ if __name__ == "__main__":
 
     # test updates from all tags
     from_tags = [update_fname.split("--")[0] for update_fname in os.listdir("sql/updates")]
-    latest_version = "0.0.5"
+    latest_version = "main"
 
     pg_version = None if not 'PG_VERSION' in os.environ else os.environ['PG_VERSION']
     for from_tag in from_tags:

--- a/scripts/test_updates.py
+++ b/scripts/test_updates.py
@@ -14,6 +14,7 @@ def update_from_tag(from_version: str, to_version: str):
     repo = git.Repo(search_parent_directories=True)
     sha_before = repo.head.object.hexsha
     repo.remotes[0].fetch()
+
     repo.git.checkout(from_tag)
     sha_after = repo.head.object.hexsha
     print("sha_after", sha_after)


### PR DESCRIPTION
Currently CI runs fail once a PR is merged, even though all tests pass while the change is an open PR.

The culprit is the recently added version update script. It seems somehow repo tags exist while the CI/CD is running on a pr but the repo tags are missing once CI/CD is running on the merged commit on main.

[This](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches) made me think that the checkout action by default does not pull tag info and this PR attempts to fix it.

@var77, Do you think this the issue? Do you think my changes would fix it?
Is there a way to test this before we merge?