### PR TITLE
fix incorrect minor version for postgres 13

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        pg: ["11.21", "12.16", "13.2", "14.9", "15.4", "16.0"]
+        pg: ["11.21", "12.16", "13.12", "14.9", "15.4", "16.0"]
     steps:
     - name: Enable UBSan if this is a release
       if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
asan workflow incorrectly builds against an old version of postgres13 that's missing some macros we need to validate indices