### PR TITLE
cmake/FindPostgreSQL: put the server include dir first

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -91,7 +91,7 @@ if(PostgreSQL_FOUND)
   separate_arguments(_pg_ldflags_ex)
 
   set(_server_lib_dirs ${_pg_libdir} ${_pg_pkglibdir})
-  set(_server_inc_dirs ${_pg_pkgincludedir} ${_pg_includedir_server})
+  set(_server_inc_dirs ${_pg_includedir_server} ${_pg_pkgincludedir})
   string(REPLACE ";" " " _shared_link_options
                  "${_pg_ldflags};${_pg_ldflags_sl}")
   set(_link_options ${_pg_ldflags})


### PR DESCRIPTION
An issue with PG_VERSION_NUM definition for PostgreSQL < 15 has been revealed by #211: PG_VERSION_NUM is defined for PostgreSQL 16.

Inside the build environment for PostgreSQL 15 it looks like the following:

```
> grep -R PG_VERSION_NUM /usr/include/
/usr/include/postgresql/pg_config.h:#define PG_VERSION_NUM 160000
/usr/include/postgresql/15/server/pg_config.h:#define PG_VERSION_NUM 150004
/usr/include/postgresql/15/server/fmgr.h:       PG_VERSION_NUM / 100, \
```

And the build command for, for example, `src/hnsw/external_index.c` looks like this:

```
/usr/bin/cc -DLANTERN_USE_USEARCH -Dlantern_EXPORTS
-I/tmp/lantern/./third_party/usearch/c -isystem /usr/include/postgresql
-isystem /usr/include/postgresql/15/server -isystem /tmp/lantern/src
-isystem /tmp/lantern -Wall -Wextra -Wno-conversion -Wno-unknown-pragmas
-fPIC -MD -MT CMakeFiles/lantern.dir/src/hnsw/external_index.c.o -MF
CMakeFiles/lantern.dir/src/hnsw/external_index.c.o.d -o
CMakeFiles/lantern.dir/src/hnsw/external_index.c.o -c
/tmp/lantern/src/hnsw/external_index.c
```
We see
```
-isystem /usr/include/postgresql
```
followed by
```
-isystem /usr/include/postgresql/15/server
```
which means that `PG_VERSION_NUM` would be defined as `160000`.

We see that the first file is from `libpq-dev`, which is not being used by Lantern.
```
> dpkg -S /usr/include/postgresql/pg_config.h
libpq-dev: /usr/include/postgresql/pg_config.h
> dpkg -S /usr/include/postgresql/15/server/pg_config.h
postgresql-server-dev-15: /usr/include/postgresql/15/server/pg_config.h
```
This patch changes the order of directories for header search to use the server dir first, so the right `PG_VERSION_NUM` would be defined for builds for the older PostgreSQL versions.