### PR TITLE
Narek/release0.0.7: Handle binary updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,9 @@ endif()
 set(_script_file "lantern--${LANTERNDB_VERSION}.sql")
 set (_update_files
   sql/updates/0.0.4--0.0.5.sql
-  sql/updates/0.0.5--0.0.6.sql)
+  sql/updates/0.0.5--0.0.6.sql
+  sql/updates/0.0.6--0.0.7.sql
+)
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/${_script_file}

--- a/sql/updates/0.0.6--0.0.7.sql
+++ b/sql/updates/0.0.6--0.0.7.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION _lantern_internal.reindex_lantern_indexes()
+RETURNS VOID AS $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT indexname FROM pg_indexes
+            WHERE indexdef ILIKE '%USING hnsw%' OR indexdef ILIKE '%USING lantern_hnsw%'
+    LOOP
+        RAISE NOTICE 'Reindexing index: %', r.indexname;
+        EXECUTE 'REINDEX INDEX ' || quote_ident(r.indexname) || ';';
+        RAISE NOTICE 'Reindexed index: %', r.indexname;
+    END LOOP;
+END $$ LANGUAGE plpgsql VOLATILE;
+
+-- Storage format changelog:
+-- Initial mechanism of this changelog
+-- Change index header magic to check the mechanism works
+SELECT _lantern_internal.reindex_lantern_indexes();

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -16,7 +16,7 @@
 #include "options.h"
 #include "usearch.h"
 
-#define LDB_WAL_MAGIC_NUMBER   0xa47e20db
+#define LDB_WAL_MAGIC_NUMBER   0xa47e60db
 #define LDB_WAL_VERSION_NUMBER 0x00000001
 
 // used for code clarity when modifying WAL entries

--- a/test/expected/ext_relocation.out
+++ b/test/expected/ext_relocation.out
@@ -31,19 +31,20 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_namespace AS ne ON (ne.oid = e.extnamespace)
     INNER JOIN pg_catalog.pg_namespace AS np ON (np.oid = p.pronamespace)
 WHERE d.deptype = 'e' AND e.extname = 'lantern'
-ORDER BY 1, 3;
+ORDER BY 1, 3, 2;
  extschema |           proname            |     proschema     
 -----------+------------------------------+-------------------
- schema1   | validate_index               | _lantern_internal
- schema1   | failure_point_enable         | _lantern_internal
  schema1   | _create_ldb_operator_classes | _lantern_internal
- schema1   | l2sq_dist                    | schema1
- schema1   | hnsw_handler                 | schema1
- schema1   | hamming_dist                 | schema1
+ schema1   | failure_point_enable         | _lantern_internal
+ schema1   | reindex_lantern_indexes      | _lantern_internal
+ schema1   | validate_index               | _lantern_internal
  schema1   | cos_dist                     | schema1
+ schema1   | hamming_dist                 | schema1
+ schema1   | hnsw_handler                 | schema1
+ schema1   | l2sq_dist                    | schema1
  schema1   | ldb_generic_dist             | schema1
  schema1   | ldb_generic_dist             | schema1
-(9 rows)
+(10 rows)
 
 -- show all the extension operators
 SELECT ne.nspname AS extschema, op.oprname, np.nspname AS proschema

--- a/test/sql/ext_relocation.sql
+++ b/test/sql/ext_relocation.sql
@@ -19,7 +19,7 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_namespace AS ne ON (ne.oid = e.extnamespace)
     INNER JOIN pg_catalog.pg_namespace AS np ON (np.oid = p.pronamespace)
 WHERE d.deptype = 'e' AND e.extname = 'lantern'
-ORDER BY 1, 3;
+ORDER BY 1, 3, 2;
 
 -- show all the extension operators
 SELECT ne.nspname AS extschema, op.oprname, np.nspname AS proschema


### PR DESCRIPTION
    Add update routine that handles index format changes

    So far update scripts only made changes in the SQL layer
    This works so long as the data structures in the old Lantern and
    new lantern versions are compatible.

    This is not the case when we change storage format, or header page,
    for example.

    To mitigate this,we can either:
    1. Write binary level update routines that patch necessary DB and lanter
     index pages
    2. Recreate all binary data structures by rerunning equivalent SQL-level
     statements

    This commit implements the second approach. We can stil have one-off
    cases of the first. But, whenever something in the binary formats of
    lantern chagnes and a specific migration script (1) does not exist,
    the 2nd approach must appropriately be integrated, as demonstrated in
    this commit