### PR TITLE
Fix wrong memory context for allocation in op_rewrite.c

### DIFF
--- a/src/hooks/op_rewrite.c
+++ b/src/hooks/op_rewrite.c
@@ -203,7 +203,7 @@ static Node *operator_rewriting_mutator(Node *node, void *ctx)
                     Relation  index = index_open(indexid, AccessShareLock);
                     Oid       indexfunc = get_func_id_from_index(index);
                     if(OidIsValid(indexfunc)) {
-                        MemoryContext old = MemoryContextSwitchTo(MessageContext);
+                        MemoryContext old = MemoryContextSwitchTo(PortalContext);
                         FuncExpr     *fnExpr = makeNode(FuncExpr);
                         fnExpr->funcresulttype = opExpr->opresulttype;
                         fnExpr->funcretset = opExpr->opretset;


### PR DESCRIPTION
The nodes were being allocated in `MessageContext` which doesn't live long enough and in some cases it was causing segfault when postgres was trying to access the nodes. Per [source-code](https://doxygen.postgresql.org/pquery_8c.html#a53a9d1887eabd76cd7f9e3be4b5ac62c) the plan tree is being allocated in `PortalContext`, so we also should allocate the overwritten nodes in `PortalContext`