### PR TITLE
Add test to catch crash when creating extension in transaction and using operator in the same tx

### DIFF
--- a/test/expected/hnsw_op_rewrite.out
+++ b/test/expected/hnsw_op_rewrite.out
@@ -8,9 +8,38 @@ DROP EXTENSION IF EXISTS lantern CASCADE;
 CREATE EXTENSION lantern;
 \set ON_ERROR_STOP off
 SELECT ARRAY[1,1] <-> ARRAY[1,1];
-ERROR:  Operator <-> is invalid outside of ORDER BY context
 ROLLBACK;
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+-- This case were causing: ERROR:  unrecognized node type: 233
+-- And sometimes Segfault as well
+-- This is caused when trying to call expression_tree_mutator with OidList_T node
+BEGIN;
+\set ON_ERROR_STOP off
+DROP TABLE IF EXISTS t1 CASCADE;
+NOTICE:  table "t1" does not exist, skipping
+CREATE TABLE t1 (
+    id TEXT PRIMARY KEY,
+    v REAL[]
+);
+DROP TABLE IF EXISTS t2 CASCADE;
+NOTICE:  table "t2" does not exist, skipping
+CREATE TABLE t2 (
+    id SERIAL PRIMARY KEY,
+    t1_id TEXT,
+    CONSTRAINT fk_t1 FOREIGN KEY(t1_id) REFERENCES t1(id)
+);
+INSERT INTO t1 (id, v) VALUES ('1', ARRAY[0,0,0]);
+CREATE INDEX ON t1 USING hnsw(v dist_cos_ops) WITH (m=32, ef_construction=128, ef=64);
+INFO:  done init usearch index
+INFO:  inserted 1 elements
+INFO:  done saving 1 vectors
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+END;

--- a/test/expected/hnsw_op_rewrite.out
+++ b/test/expected/hnsw_op_rewrite.out
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------
+-- Test Database Crashes which were caused by operator rewriting logic
+---------------------------------------------------------------------
+-- This case were causing Segfault from
+-- post_parse_analyze_hook_with_operator_check() -> ldb_get_operator_oids() -> ... LookupOperName() ... -> GetRealCmin()
+BEGIN;
+DROP EXTENSION IF EXISTS lantern CASCADE;
+CREATE EXTENSION lantern;
+\set ON_ERROR_STOP off
+SELECT ARRAY[1,1] <-> ARRAY[1,1];
+ERROR:  Operator <-> is invalid outside of ORDER BY context
+ROLLBACK;
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -3,5 +3,5 @@
 # - every test that needs to be run iff pgvector is installed appears in a 'test_pgvector:' line
 # - 'test' lines may have multiple space-separated tests. All tests in a single 'test' line will be run in parallel
 
-test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate ext_relocation hnsw_ef_search hnsw_failure_point
+test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate ext_relocation hnsw_ef_search hnsw_failure_point hnsw_op_rewrite
 test_pgvector: hnsw_vector

--- a/test/sql/hnsw_op_rewrite.sql
+++ b/test/sql/hnsw_op_rewrite.sql
@@ -1,8 +1,6 @@
 ---------------------------------------------------------------------
 -- Test Database Crashes which were caused by operator rewriting logic
 ---------------------------------------------------------------------
-
-
 -- This case were causing Segfault from
 -- post_parse_analyze_hook_with_operator_check() -> ldb_get_operator_oids() -> ... LookupOperName() ... -> GetRealCmin()
 BEGIN;
@@ -11,3 +9,38 @@ CREATE EXTENSION lantern;
 \set ON_ERROR_STOP off
 SELECT ARRAY[1,1] <-> ARRAY[1,1];
 ROLLBACK;
+
+-- This case were causing: ERROR:  unrecognized node type: 233
+-- And sometimes Segfault as well
+-- This is caused when trying to call expression_tree_mutator with OidList_T node
+BEGIN;
+\set ON_ERROR_STOP off
+DROP TABLE IF EXISTS t1 CASCADE;
+CREATE TABLE t1 (
+    id TEXT PRIMARY KEY,
+    v REAL[]
+);
+
+DROP TABLE IF EXISTS t2 CASCADE;
+CREATE TABLE t2 (
+    id SERIAL PRIMARY KEY,
+    t1_id TEXT,
+    CONSTRAINT fk_t1 FOREIGN KEY(t1_id) REFERENCES t1(id)
+);
+
+INSERT INTO t1 (id, v) VALUES ('1', ARRAY[0,0,0]);
+
+CREATE INDEX ON t1 USING hnsw(v dist_cos_ops) WITH (m=32, ef_construction=128, ef=64);
+
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+INSERT INTO t2 (t1_id) VALUES ('1');
+END;
+

--- a/test/sql/hnsw_op_rewrite.sql
+++ b/test/sql/hnsw_op_rewrite.sql
@@ -1,0 +1,13 @@
+---------------------------------------------------------------------
+-- Test Database Crashes which were caused by operator rewriting logic
+---------------------------------------------------------------------
+
+
+-- This case were causing Segfault from
+-- post_parse_analyze_hook_with_operator_check() -> ldb_get_operator_oids() -> ... LookupOperName() ... -> GetRealCmin()
+BEGIN;
+DROP EXTENSION IF EXISTS lantern CASCADE;
+CREATE EXTENSION lantern;
+\set ON_ERROR_STOP off
+SELECT ARRAY[1,1] <-> ARRAY[1,1];
+ROLLBACK;


### PR DESCRIPTION
The database crash is happening if extension is being created in the same transaction when operator is used. Postgres failed to lookup the operator oid by name and crashes with segfault.

Here is the full backtrace of crash:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000562e35e57874 in GetRealCmin (combocid=3) at combocid.c:282
282             return comboCids[combocid].cmin;
(gdb) bt
#0  0x0000562e35e57874 in GetRealCmin (combocid=3) at combocid.c:282
]#1  HeapTupleHeaderGetCmin (tup=tup@entry=0x7f7b521d0060) at combocid.c:112
#2  0x0000562e35a512b2 in HeapTupleSatisfiesMVCC (htup=0x1, htup=0x1, buffer=1, snapshot=0x562e37b81df8)
    at heapam_visibility.c:1013
#3  HeapTupleSatisfiesVisibility (tup=tup@entry=0x562e37b49608, snapshot=snapshot@entry=0x562e37b81df8,
    buffer=buffer@entry=1) at heapam_visibility.c:1771
#4  0x0000562e35a463f5 in heap_hot_search_buffer (tid=tid@entry=0x562e37b49728, relation=0x7f7b519fc350, buffer=1,
    snapshot=snapshot@entry=0x562e37b81df8, heapTuple=heapTuple@entry=0x562e37b49608,
    all_dead=all_dead@entry=0x7ffed209e087, first_call=true) at heapam.c:1764
#5  0x0000562e35a4de54 in heapam_index_fetch_tuple (scan=0x562e37b499f8, tid=0x562e37b49728,
    snapshot=0x562e37b81df8, slot=0x562e37b495b8, call_again=0x562e37b4972e, all_dead=0x7ffed209e087)
    at heapam_handler.c:143
#6  0x0000562e35a5bc4d in table_index_fetch_tuple (all_dead=0x7ffed209e087, call_again=0x562e37b4972e,
    slot=<optimized out>, snapshot=<optimized out>, tid=0x562e37b49728, scan=<optimized out>)
    at ../../../../src/include/access/tableam.h:1226
#7  index_fetch_heap (scan=0x562e37b496c8, slot=<optimized out>) at indexam.c:580
#8  0x0000562e35a5bd05 in index_getnext_slot (scan=0x562e37b496c8, direction=direction@entry=ForwardScanDirection,
    slot=0x562e37b495b8) at indexam.c:640
#9  0x0000562e35a5b187 in systable_getnext (sysscan=sysscan@entry=0x562e37b49568) at genam.c:511
#10 0x0000562e35e084fa in SearchCatCacheList (cache=0x562e37bb9280, nkeys=nkeys@entry=3, v1=140167779025004,
    v2=v2@entry=1007, v3=v3@entry=1007) at catcache.c:1639
#11 0x0000562e35e1991d in SearchSysCacheList (cacheId=cacheId@entry=37, nkeys=nkeys@entry=3, key1=<optimized out>,
    key2=key2@entry=1007, key3=key3@entry=1007) at syscache.c:1493
#12 0x0000562e35ac7371 in OpernameGetOprid (names=names@entry=0x562e37b49518, oprleft=oprleft@entry=1007,
    oprright=oprright@entry=1007) at namespace.c:1568
#13 0x0000562e35b09e31 in LookupOperName (pstate=0x0, opername=0x562e37b49518, oprleft=1007, oprright=1007,
    noError=<optimized out>, location=-1) at parse_oper.c:106
#14 0x00007f7b5aa91f91 in ldb_get_operator_oids () at /root/lantern/src/hooks/utils.c:14
#15 0x00007f7b5aa91e88 in post_parse_analyze_hook_with_operator_check (pstate=0x562e37b492d8, query=0x562e37b493e8,
    jstate=0x0) at /root/lantern/src/hooks/post_parse.c:173
#16 0x0000562e35ae42bc in parse_analyze_fixedparams (parseTree=parseTree@entry=0x562e37b49258,
    sourceText=sourceText@entry=0x562e37b48858 "END;", paramTypes=paramTypes@entry=0x0,
    numParams=numParams@entry=0, queryEnv=queryEnv@entry=0x0) at analyze.c:129
#17 0x0000562e35cfca1b in pg_analyze_and_rewrite_fixedparams (queryEnv=0x0, numParams=0, paramTypes=0x0,
    query_string=0x562e37b48858 "END;", parsetree=0x562e37b49258) at postgres.c:657
#18 exec_simple_query (query_string=0x562e37b48858 "END;") at postgres.c:1166
#19 0x0000562e35cfec25 in PostgresMain (dbname=<optimized out>, username=<optimized out>) at postgres.c:4593
#20 0x0000562e35c7f08d in BackendRun (port=0x562e37b7f2d0, port=0x562e37b7f2d0) at postmaster.c:4511
#21 BackendStartup (port=0x562e37b7f2d0) at postmaster.c:4239
#22 ServerLoop () at postmaster.c:1806
#23 0x0000562e35c7fff3 in PostmasterMain (argc=argc@entry=3, argv=argv@entry=0x562e37b44390) at postmaster.c:1478
#24 0x0000562e35a068ff in main (argc=3, argv=0x562e37b44390) at main.c:202

```