### PR TITLE
Add C client tests to catch op_rewriting segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BUILD_LIBHNSW "Build libhnsw as hnsw provider" OFF)
 option(CODECOVERAGE "Enable code coverage for the build" OFF)
 option(BENCH "Enable benchmarking" OFF)
 option(FAILURE_POINTS "Enable failure points" ON)
+option(BUILD_C_TESTS "Build C client tests" OFF)
 
 if(CODECOVERAGE)
   message(STATUS "Code coverage is enabled.")
@@ -77,7 +78,6 @@ set(USEARCH_DEBUG_BUILD_ASAN OFF)
 # which causes issues when built from docker on m1 macs
 # set(USEARCH_NO_MARCH_NATIVE OFF)
 set(USEARCH_BUILD_TEST OFF)
-set(LANTERN_BUILD_C_TESTS ON)
 set(USEARCH_BUILD_BENCHMARK OFF)
 add_subdirectory("./third_party/usearch/c")
 
@@ -93,8 +93,8 @@ endif()
 # ADD LanternDB! Let there be light!
 add_library(lantern MODULE ${SOURCES})
 
-# ============= Lantern Client tests ===============
-if (LANTERN_BUILD_C_TESTS)
+# ============= Lantern tests with C libpq ==========
+if (BUILD_C_TESTS)
   add_executable(lantern_c_tests "test/c/runner.c")
   # Add postgres header include dirs
   target_include_directories(
@@ -104,6 +104,13 @@ if (LANTERN_BUILD_C_TESTS)
   target_link_directories(lantern_c_tests PRIVATE ${PostgreSQL_LIBRARY_DIRS})
   # Link libpq
   target_link_libraries(lantern_c_tests "-lpq")
+  
+  add_custom_target(
+    test-client
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/run_all_tests.sh --client
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/
+  )
+  add_dependencies(test-client lantern_c_tests)
 endif()
 # ==================================================
 
@@ -237,12 +244,6 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
 )
 
-add_custom_target(
-  test-c
-  COMMAND ${CMAKE_SOURCE_DIR}/scripts/run_all_tests.sh --c
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/
-)
-
 # BENCHMARK
 add_custom_target(
   benchmark
@@ -309,7 +310,6 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_dependencies(archive lantern)
-add_dependencies(test-c lantern_c_tests)
 
 # Debian packaging
 set(CPACK_GENERATOR "DEB")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,7 @@ if (LANTERN_BUILD_C_TESTS)
   # Add link directories for postgres shared libraries
   target_link_directories(lantern_c_tests PRIVATE ${PostgreSQL_LIBRARY_DIRS})
   # Link libpq
-  set_target_properties(
-    lantern_c_tests
-    PROPERTIES PREFIX ""
-               LINK_FLAGS "-lpq"
-               POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(lantern_c_tests "-lpq")
 endif()
 # ==================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(USEARCH_DEBUG_BUILD_ASAN OFF)
 # which causes issues when built from docker on m1 macs
 # set(USEARCH_NO_MARCH_NATIVE OFF)
 set(USEARCH_BUILD_TEST OFF)
+set(LANTERN_BUILD_C_TESTS ON)
 set(USEARCH_BUILD_BENCHMARK OFF)
 add_subdirectory("./third_party/usearch/c")
 
@@ -91,6 +92,24 @@ endif()
 
 # ADD LanternDB! Let there be light!
 add_library(lantern MODULE ${SOURCES})
+
+# ============= Lantern Client tests ===============
+if (LANTERN_BUILD_C_TESTS)
+  add_executable(lantern_c_tests "test/c/runner.c")
+  # Add postgres header include dirs
+  target_include_directories(
+    lantern_c_tests
+    SYSTEM PRIVATE ${PostgreSQL_INCLUDE_DIRS})
+  # Add link directories for postgres shared libraries
+  target_link_directories(lantern_c_tests PRIVATE ${PostgreSQL_LIBRARY_DIRS})
+  # Link libpq
+  set_target_properties(
+    lantern_c_tests
+    PROPERTIES PREFIX ""
+               LINK_FLAGS "-lpq"
+               POSITION_INDEPENDENT_CODE ON)
+endif()
+# ==================================================
 
 # Add postgres extension packaging rules
 target_include_directories(
@@ -222,6 +241,12 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
 )
 
+add_custom_target(
+  test-c
+  COMMAND ${CMAKE_SOURCE_DIR}/scripts/run_all_tests.sh --c
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/
+)
+
 # BENCHMARK
 add_custom_target(
   benchmark
@@ -288,6 +313,7 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_dependencies(archive lantern)
+add_dependencies(test-c lantern_c_tests)
 
 # Debian packaging
 set(CPACK_GENERATOR "DEB")

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -59,7 +59,7 @@ function build_and_install() {
   
   if [ -n "$ENABLE_COVERAGE" ]
   then
-    flags="$flags -DCMAKE_C_COMPILER=/usr/bin/gcc -DCODECOVERAGE=ON"
+    flags="$flags -DCMAKE_C_COMPILER=/usr/bin/gcc -DCODECOVERAGE=ON -DBUILD_C_TESTS=ON"
   fi
 
   # Run cmake

--- a/ci/scripts/run-tests-linux.sh
+++ b/ci/scripts/run-tests-linux.sh
@@ -27,6 +27,7 @@ function run_db_tests(){
   then
     cd $WORKDIR/build && \
     make test && \
+    make test-c
     killall postgres && \
     gcovr -r $WORKDIR/src/ --object-directory $WORKDIR/build/ --xml /tmp/coverage.xml
   fi

--- a/ci/scripts/run-tests-linux.sh
+++ b/ci/scripts/run-tests-linux.sh
@@ -27,7 +27,7 @@ function run_db_tests(){
   then
     cd $WORKDIR/build && \
     make test && \
-    make test-c
+    make test-client
     killall postgres && \
     gcovr -r $WORKDIR/src/ --object-directory $WORKDIR/build/ --xml /tmp/coverage.xml
   fi

--- a/ci/scripts/run-tests-mac.sh
+++ b/ci/scripts/run-tests-mac.sh
@@ -22,4 +22,4 @@ wait_for_pg(){
 # Start database
 brew services start postgresql@$PG_VERSION
 
-wait_for_pg && cd $WORKDIR/build && make test && make test-parallel
+wait_for_pg && cd $WORKDIR/build && make test && make test-parallel && make test-client

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -27,8 +27,6 @@ DB_USER="${DB_USER:-$DEFAULT_USER}"
 # this will be used by pg_regress while making diff file
 export PG_REGRESS_DIFF_OPTS=-u
 
-echo "Filter: $FILTER"
-
 mkdir -p $TMP_OUTDIR
 
 # if $TMP_ROOT/vector_datasets does not exist
@@ -76,13 +74,20 @@ pgvector_installed=$($PSQL -U $DB_USER -d postgres -c "SELECT 1 FROM pg_availabl
 # Settings
 REGRESSION=0
 PARALLEL=0
+C_TESTS=0
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --regression) REGRESSION=1 ;;
         --parallel) PARALLEL=1 ;;
+        --c) C_TESTS=1 ;;
     esac
     shift
 done
+
+if [ "$C_TESTS" -eq 1 ]; then
+    DB_USER=$DB_USER TEST_DB_NAME=$TESTDB ./bin/lantern_c_tests
+    exit $?
+fi
 
 FIRST_TEST=1
 function print_test {

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -79,7 +79,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --regression) REGRESSION=1 ;;
         --parallel) PARALLEL=1 ;;
-        --c) C_TESTS=1 ;;
+        --client) C_TESTS=1 ;;
     esac
     shift
 done

--- a/src/hooks/op_rewrite.c
+++ b/src/hooks/op_rewrite.c
@@ -249,7 +249,7 @@ static Node *operator_rewriting_mutator(Node *node, void *ctx)
     }
 
     if(IsA(node, List)) {
-        MemoryContext old = MemoryContextSwitchTo(MessageContext);
+        MemoryContext old = MemoryContextSwitchTo(PortalContext);
         List         *list = (List *)node;
         List         *ret = NIL;
         ListCell     *lc;

--- a/src/hooks/op_rewrite.c
+++ b/src/hooks/op_rewrite.c
@@ -249,7 +249,7 @@ static Node *operator_rewriting_mutator(Node *node, void *ctx)
     }
 
     if(IsA(node, List)) {
-        MemoryContext old = MemoryContextSwitchTo(PortalContext);
+        MemoryContext old = MemoryContextSwitchTo(MessageContext);
         List         *list = (List *)node;
         List         *ret = NIL;
         ListCell     *lc;

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -83,6 +83,17 @@ int create_extension(PGconn *conn)
     return 0;
 }
 
+const char *getenv_or_default(const char *env_name, const char *default_val)
+{
+    const char *val = getenv(env_name);
+
+    if(val == NULL) {
+        return default_val;
+    }
+
+    return val;
+}
+
 int main()
 {
     size_t          i;
@@ -94,34 +105,14 @@ int main()
     };
 
     // Set up database connection variables
-    const char *DB_HOST = getenv("DB_HOST");
-    const char *DB_PORT = getenv("DB_PORT");
-    const char *DB_USER = getenv("DB_USER");
-    const char *DB_PASSWORD = getenv("DB_PASSWORD");
-    const char *TEST_DB_NAME = getenv("TEST_DB_NAME");
+    const char *DB_HOST = getenv_or_default("DB_HOST", "localhost");
+    const char *DB_PORT = getenv_or_default("DB_PORT", "5432");
+    const char *DB_USER = getenv_or_default("DB_USER", "postgres");
+    const char *DB_PASSWORD = getenv_or_default("DB_PASSWORD", "");
+    const char *TEST_DB_NAME = getenv_or_default("TEST_DB_NAME", "lantern_testdb");
     const char *ROOT_DB_NAME = "postgres";
     PGconn     *test_conn = NULL;
     PGconn     *root_conn = NULL;
-
-    if(DB_HOST == NULL) {
-        DB_HOST = "localhost";
-    }
-
-    if(DB_PORT == NULL) {
-        DB_PORT = "5432";
-    }
-
-    if(DB_USER == NULL) {
-        DB_USER = "postgres";
-    }
-
-    if(DB_PASSWORD == NULL) {
-        DB_PASSWORD = "";
-    }
-
-    if(TEST_DB_NAME == NULL) {
-        TEST_DB_NAME = "lantern_testdb";
-    }
 
     root_conn = connect_database(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, ROOT_DB_NAME);
 

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -1,0 +1,165 @@
+#include <libpq-fe.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Include your test files here
+#include "test_op_rewrite.c"
+// ===========================
+
+typedef int (*TestCaseFunction)(PGconn *);
+
+struct TestCase
+{
+    char            *name;
+    TestCaseFunction func;
+};
+
+PGconn *connect_database(
+    const char *db_host, const char *db_port, const char *db_user, const char *db_password, const char *db_name)
+{
+    const int const_db_uri_chars = strlen("host= port= user= dbname= password=");
+    char *db_uri = malloc(strlen(db_host) + strlen(db_port) + strlen(db_user) + strlen(db_password) + strlen(db_name)
+                          + const_db_uri_chars);
+    sprintf(db_uri, "host=%s port=%s user=%s dbname=%s password=%s", db_host, db_port, db_user, db_name, db_password);
+
+    PGconn *conn = PQconnectdb(db_uri);
+    free(db_uri);
+
+    if(PQstatus(conn) != CONNECTION_OK) {
+        fprintf(stderr, "Connection to database failed: %s\n", PQerrorMessage(conn));
+        PQfinish(conn);
+        return NULL;
+    }
+    return conn;
+}
+
+int recreate_database(PGconn *root_conn, const char *test_db_name)
+{
+    char *statement = "DROP DATABASE IF EXISTS ";
+    char *full_statement = malloc(strlen(statement) + strlen(test_db_name));
+    sprintf(full_statement, "%s%s", statement, test_db_name);
+    PGresult *res = PQexec(root_conn, full_statement);
+    free(full_statement);
+
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to drop test db: %s\n", PQerrorMessage(root_conn));
+        PQclear(res);
+        return 1;
+    }
+
+    statement = "CREATE DATABASE ";
+    full_statement = malloc(strlen(statement) + strlen(test_db_name));
+    sprintf(full_statement, "%s%s", statement, test_db_name);
+    res = PQexec(root_conn, full_statement);
+    printf("%s\n", full_statement);
+    free(full_statement);
+
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create test db: %s\n", PQerrorMessage(root_conn));
+        PQclear(res);
+        return 1;
+    }
+
+    PQclear(res);
+    return 0;
+}
+
+int create_extension(PGconn *conn)
+{
+    PGresult *res = PQexec(conn, "CREATE EXTENSION IF NOT EXISTS lantern");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create extension: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+    PQclear(res);
+    return 0;
+}
+
+int main()
+{
+    size_t          i;
+    struct TestCase current_case;
+    struct TestCase test_cases[] = {
+        // Add new test files here to be run
+        {.name = "test_op_rewrite", .func = (TestCaseFunction)test_op_rewrite}
+        // ================================
+    };
+
+    // Set up database connection variables
+    const char *DB_HOST = getenv("DB_HOST");
+    const char *DB_PORT = getenv("DB_PORT");
+    const char *DB_USER = getenv("DB_USER");
+    const char *DB_PASSWORD = getenv("DB_PASSWORD");
+    const char *TEST_DB_NAME = getenv("TEST_DB_NAME");
+    const char *ROOT_DB_NAME = "postgres";
+    PGconn     *test_conn = NULL;
+    PGconn     *root_conn = NULL;
+
+    if(DB_HOST == NULL) {
+        DB_HOST = "localhost";
+    }
+
+    if(DB_PORT == NULL) {
+        DB_PORT = "5432";
+    }
+
+    if(DB_USER == NULL) {
+        DB_USER = "postgres";
+    }
+
+    if(DB_PASSWORD == NULL) {
+        DB_PASSWORD = "";
+    }
+
+    if(TEST_DB_NAME == NULL) {
+        TEST_DB_NAME = "lantern_testdb";
+    }
+
+    root_conn = connect_database(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, ROOT_DB_NAME);
+
+    if(root_conn == NULL) {
+        return 1;
+    }
+
+    for(i = 0; i < sizeof(test_cases) / sizeof(struct TestCase); i++) {
+        current_case = test_cases[ i ];
+        printf("[+] Running test case '%s'\n", current_case.name);
+
+        // Create test database
+        if(recreate_database(root_conn, TEST_DB_NAME)) {
+            fprintf(stderr, "[X] Failed to recreate test database\n");
+            return 1;
+        }
+
+        // Connect to test database
+        test_conn = connect_database(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, TEST_DB_NAME);
+
+        if(test_conn == NULL) {
+            return 1;
+        }
+
+        // Create lantern extensionk
+        if(create_extension(test_conn)) {
+            fprintf(stderr, "[X] Failed to create extension\n");
+            return 1;
+        }
+
+        // Execute test case
+        if(current_case.func(test_conn)) {
+            fprintf(stderr, "[X] Test case '%s' failed\n", current_case.name);
+            PQfinish(test_conn);
+            PQfinish(root_conn);
+            return 1;
+        }
+
+        // Close test connection
+        PQfinish(test_conn);
+    }
+
+    PQfinish(root_conn);
+    printf("[+] All tests passed");
+    return 0;
+}

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -19,7 +19,7 @@ struct TestCase
 PGconn *connect_database(
     const char *db_host, const char *db_port, const char *db_user, const char *db_password, const char *db_name)
 {
-    const int const_db_uri_chars = strlen("host= port= user= dbname= sslmode=disable password=");
+    const int const_db_uri_chars = strlen("host= port= user= dbname= sslmode=disable password=") + 1;
     char *db_uri = malloc(strlen(db_host) + strlen(db_port) + strlen(db_user) + strlen(db_password) + strlen(db_name)
                           + const_db_uri_chars);
     sprintf(db_uri,
@@ -44,7 +44,7 @@ PGconn *connect_database(
 int recreate_database(PGconn *root_conn, const char *test_db_name)
 {
     char *statement = "DROP DATABASE IF EXISTS ";
-    char *full_statement = malloc(strlen(statement) + strlen(test_db_name));
+    char *full_statement = malloc(strlen(statement) + strlen(test_db_name) + 1);
     sprintf(full_statement, "%s%s", statement, test_db_name);
     PGresult *res = PQexec(root_conn, full_statement);
     free(full_statement);
@@ -56,7 +56,7 @@ int recreate_database(PGconn *root_conn, const char *test_db_name)
     }
 
     statement = "CREATE DATABASE ";
-    full_statement = malloc(strlen(statement) + strlen(test_db_name));
+    full_statement = malloc(strlen(statement) + strlen(test_db_name) + 1);
     sprintf(full_statement, "%s%s", statement, test_db_name);
     res = PQexec(root_conn, full_statement);
     free(full_statement);

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -19,10 +19,16 @@ struct TestCase
 PGconn *connect_database(
     const char *db_host, const char *db_port, const char *db_user, const char *db_password, const char *db_name)
 {
-    const int const_db_uri_chars = strlen("host= port= user= dbname= password=");
+    const int const_db_uri_chars = strlen("host= port= user= dbname= sslmode=disable password=");
     char *db_uri = malloc(strlen(db_host) + strlen(db_port) + strlen(db_user) + strlen(db_password) + strlen(db_name)
                           + const_db_uri_chars);
-    sprintf(db_uri, "host=%s port=%s user=%s dbname=%s password=%s", db_host, db_port, db_user, db_name, db_password);
+    sprintf(db_uri,
+            "host=%s port=%s user=%s dbname=%s sslmode=disable password=%s",
+            db_host,
+            db_port,
+            db_user,
+            db_name,
+            db_password);
 
     PGconn *conn = PQconnectdb(db_uri);
     free(db_uri);
@@ -160,6 +166,6 @@ int main()
     }
 
     PQfinish(root_conn);
-    printf("[+] All tests passed");
+    printf("[+] All tests passed\n");
     return 0;
 }

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -59,7 +59,6 @@ int recreate_database(PGconn *root_conn, const char *test_db_name)
     full_statement = malloc(strlen(statement) + strlen(test_db_name));
     sprintf(full_statement, "%s%s", statement, test_db_name);
     res = PQexec(root_conn, full_statement);
-    printf("%s\n", full_statement);
     free(full_statement);
 
     if(PQresultStatus(res) != PGRES_COMMAND_OK) {
@@ -132,7 +131,7 @@ int main()
 
     for(i = 0; i < sizeof(test_cases) / sizeof(struct TestCase); i++) {
         current_case = test_cases[ i ];
-        printf("[+] Running test case '%s'\n", current_case.name);
+        printf("[+] Running test case '%s'...\n", current_case.name);
 
         // Create test database
         if(recreate_database(root_conn, TEST_DB_NAME)) {
@@ -163,6 +162,7 @@ int main()
 
         // Close test connection
         PQfinish(test_conn);
+        printf("[+] Test case '%s' passed\n", current_case.name);
     }
 
     PQfinish(root_conn);

--- a/test/c/test_op_rewrite.c
+++ b/test/c/test_op_rewrite.c
@@ -1,6 +1,3 @@
-#ifndef TEST_OP_REWRITE_H
-#define TEST_OP_REWRITE_H
-
 #include <libpq-fe.h>
 
 int test_op_rewrite(PGconn *conn)
@@ -51,4 +48,3 @@ int test_op_rewrite(PGconn *conn)
     }
     return 0;
 }
-#endif

--- a/test/c/test_op_rewrite.c
+++ b/test/c/test_op_rewrite.c
@@ -1,5 +1,5 @@
-#ifndef _TEST_OP_REWRITE
-#define _TEST_OP_REWRITE
+#ifndef TEST_OP_REWRITE_H
+#define TEST_OP_REWRITE_H
 
 #include <libpq-fe.h>
 

--- a/test/c/test_op_rewrite.c
+++ b/test/c/test_op_rewrite.c
@@ -1,0 +1,54 @@
+#ifndef _TEST_OP_REWRITE
+#define _TEST_OP_REWRITE
+
+#include <libpq-fe.h>
+
+int test_op_rewrite(PGconn *conn)
+{
+    const char *query
+        = "SELECT tablename, reltuples "
+          "FROM pg_tables "
+          "JOIN pg_class ON pg_tables.tablename = pg_class.relname "
+          "WHERE schemaname = $1;";
+
+    PGresult *res = PQexec(conn, "DROP TABLE IF EXISTS _lantern_test_op");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to drop table: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    PQclear(res);
+
+    res = PQexec(conn, "CREATE TABLE _lantern_test_op (id INT, name TEXT, v REAL[])");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create table: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+    PQclear(res);
+
+    res = PQexec(conn, "INSERT INTO _lantern_test_op(id, name, v) VALUES (1, 'n1', '{1,1}')");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        PQclear(res);
+        return 1;
+    }
+    PQclear(res);
+
+    res = PQexec(conn, "CREATE INDEX ON _lantern_test_op USING hnsw(v)");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create index: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    const char *name = "public";
+
+    res = PQexecParams(conn, query, 1, NULL, &name, NULL, NULL, 0);
+    if(PQresultStatus(res) != PGRES_TUPLES_OK) {
+        fprintf(stderr, "Failed to execute query: %s\n", PQerrorMessage(conn));
+        return 1;
+    }
+    return 0;
+}
+#endif


### PR DESCRIPTION
Added tests with C libpq client to catch the segfault happening on operator rewrite hook.

To add new tests you need to do the following:
1. Create test file under `test/c/`
2. Include test file in `test/runner.c`
3. Add test case to `test_cases[]` in `runner.c`