### PR TITLE
Fix l2 operator bug when used with int arrays

### DIFF
--- a/sql/lantern.sql
+++ b/sql/lantern.sql
@@ -139,13 +139,7 @@ BEGIN
 		CREATE FUNCTION cos_dist(vector, vector) RETURNS float8
 			AS 'MODULE_PATHNAME', 'vector_cos_dist' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 			
-		CREATE FUNCTION hamming_dist(vector, vector) RETURNS float8
-			AS 'MODULE_PATHNAME', 'vector_hamming_dist' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-			
-		CREATE OPERATOR <+> (
-			LEFTARG = vector, RIGHTARG = vector, PROCEDURE = hamming_dist,
-			COMMUTATOR = '<+>'
-		);
+		-- pgvecor's vector type requires floats and we cannot define hamming distance for floats
 
 		CREATE OPERATOR CLASS dist_vec_l2sq_ops
 			DEFAULT FOR TYPE vector USING lantern_hnsw AS
@@ -159,12 +153,6 @@ BEGIN
 			OPERATOR 2 <=> (vector, vector) FOR ORDER BY float_ops,
 			FUNCTION 2 cos_dist(vector, vector);
 			
-		CREATE OPERATOR CLASS dist_vec_hamming_ops
-			FOR TYPE vector USING lantern_hnsw AS
-			OPERATOR 1 <-> (vector, vector) FOR ORDER BY float_ops,
-			FUNCTION 1 hamming_dist(vector, vector),
-			OPERATOR 2 <+> (vector, vector) FOR ORDER BY float_ops,
-			FUNCTION 2 hamming_dist(vector, vector);
 	END IF;
 
 

--- a/sql/updates/0.0.9--0.0.10.sql
+++ b/sql/updates/0.0.9--0.0.10.sql
@@ -1,0 +1,5 @@
+-- these go for good.
+
+DROP OPERATOR CLASS IF EXISTS dist_vec_hamming_ops USING hnsw CASCADE;
+DROP FUNCTION IF EXISTS cos_dist(vector, vector);
+DROP OPERATOR <+>(vector, vector) CASCADE

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -38,7 +38,7 @@ PGDLLEXPORT Datum vector_hamming_dist(PG_FUNCTION_ARGS);
 
 HnswColumnType GetColumnTypeFromOid(Oid oid);
 HnswColumnType GetIndexColumnType(Relation index);
-void          *DatumGetSizedArray(Datum datum, HnswColumnType type, int dimensions);
+void*          DatumGetSizedArray(Datum datum, HnswColumnType type, int dimensions);
 
 #define LDB_UNUSED(x) (void)(x)
 

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -1,6 +1,7 @@
 #ifndef LDB_HNSW_UTILS_H
 #define LDB_HNSW_UTILS_H
 #include <access/amapi.h>
+#include <utils/array.h>
 
 #include "options.h"
 #include "usearch.h"
@@ -9,6 +10,7 @@ void            CheckMem(int limit, Relation index, usearch_index_t uidx, uint32
 void            LogUsearchOptions(usearch_init_options_t *opts);
 void            PopulateUsearchOpts(Relation index, usearch_init_options_t *opts);
 usearch_label_t GetUsearchLabel(ItemPointer itemPtr);
+float4         *ToFloat4Array(ArrayType *arr);
 
 static inline void ldb_invariant(bool condition, const char *msg, ...)
 {

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -9,7 +9,11 @@ set work_mem = '64kB';
 set client_min_messages = 'ERROR';
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,
-    v REAL[2]
+    v REAL[2] -- this demonstates that postgres actually does not enforce real[] length as we actually insert vectors of length 3
+);
+CREATE TABLE small_world_int (
+    id SERIAL PRIMARY KEY,
+    v INTEGER[]
 );
 CREATE INDEX ON small_world USING hnsw (v) WITH (dim=3);
 INFO:  done init usearch index
@@ -28,6 +32,9 @@ INSERT INTO small_world (v) VALUES ('{0,0,1}'), ('{0,1,0}');
 INSERT INTO small_world (v) VALUES (NULL);
 -- Attempt to insert a row with an incorrect vector length
 \set ON_ERROR_STOP off
+-- Cannot create an hnsw index with implicit typecasts (trying to cast integer[] to real[], in this case)
+CREATE INDEX ON small_world_int USING hnsw (v dist_l2sq_ops) WITH (dim=3);
+ERROR:  operator class "dist_l2sq_ops" does not accept data type integer[]
 INSERT INTO small_world (v) VALUES ('{1,1,1,1}');
 ERROR:  Wrong number of dimensions: 4 instead of 3 expected
 \set ON_ERROR_STOP on

--- a/test/expected/hnsw_operators.out
+++ b/test/expected/hnsw_operators.out
@@ -6,6 +6,7 @@ INFO:  done init usearch index
 INFO:  inserted 2 elements
 INFO:  done saving 2 vectors
 -- should rewrite operator
+SET lantern.pgvector_compat=FALSE;
 SELECT * FROM op_test ORDER BY v <-> ARRAY[1,1,1];
     v    
 ---------
@@ -27,6 +28,63 @@ ERROR:  Operator <-> is invalid outside of ORDER BY context
 SET lantern.pgvector_compat=TRUE;
 SET enable_seqscan=OFF;
 \set ON_ERROR_STOP on
+-- one-off vector distance calculations should work with relevant operator
+-- with integer arrays:
+SELECT ARRAY[0,0,0] <-> ARRAY[2,3,-4];
+ ?column? 
+----------
+       29
+(1 row)
+
+-- with float arrays:
+SELECT ARRAY[0,0,0] <-> ARRAY[2,3,-4]::real[];
+ ?column? 
+----------
+       29
+(1 row)
+
+SELECT ARRAY[0,0,0]::real[] <-> ARRAY[2,3,-4]::real[];
+ ?column? 
+----------
+       29
+(1 row)
+
+SELECT '{1,0,1}' <-> '{0,1,0}'::integer[];
+ ?column? 
+----------
+        3
+(1 row)
+
+SELECT '{1,0,1}' <=> '{0,1,0}'::integer[];
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT ROUND(num::NUMERIC, 2) FROM (SELECT '{1,1,1}' <=> '{0,1,0}'::INTEGER[] AS num) _sub;
+ round 
+-------
+  0.42
+(1 row)
+
+SELECT ARRAY[.1,0,0] <=> ARRAY[0,.5,0];
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT cos_dist(ARRAY[.1,0,0]::real[], ARRAY[0,.5,0]::real[]);
+ cos_dist 
+----------
+        1
+(1 row)
+
+SELECT ARRAY[1,0,0] <+> ARRAY[0,1,0];
+ ?column? 
+----------
+        2
+(1 row)
+
 -- NOW THIS IS TRIGGERING INDEX SCAN AS WELL
 -- BECAUSE WE ARE REGISTERING <-> FOR ALL OPERATOR CLASSES
 -- IDEALLY THIS SHOULD NOT TRIGGER INDEX SCAN WHEN lantern.pgvector_compat=TRUE

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -321,30 +321,3 @@ FROM small_world ORDER BY v <=> '[0,1,0]'::VECTOR LIMIT 7;
          Order By: (v <=> '[0,1,0]'::vector)
 (3 rows)
 
--- hamming index
-CREATE INDEX hamming_idx ON small_world  USING lantern_hnsw (v dist_vec_hamming_ops);
-INFO:  done init usearch index
-INFO:  inserted 8 elements
-INFO:  done saving 8 vectors
-SELECT ROUND((v <+> '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <+> '[0,1,0]'::VECTOR LIMIT 7;
- dist  
--------
-  0.00
-  7.00
-  7.00
-  7.00
- 14.00
- 14.00
- 14.00
-(7 rows)
-
-EXPLAIN (COSTS FALSE) SELECT ROUND((v <+> '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <+> '[0,1,0]'::VECTOR LIMIT 7;
-                    QUERY PLAN                     
----------------------------------------------------
- Limit
-   ->  Index Scan using hamming_idx on small_world
-         Order By: (v <+> '[0,1,0]'::vector)
-(3 rows)
-

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -10,8 +10,14 @@ set client_min_messages = 'ERROR';
 
 CREATE TABLE small_world (
     id SERIAL PRIMARY KEY,
-    v REAL[2]
+    v REAL[2] -- this demonstates that postgres actually does not enforce real[] length as we actually insert vectors of length 3
 );
+
+CREATE TABLE small_world_int (
+    id SERIAL PRIMARY KEY,
+    v INTEGER[]
+);
+
 CREATE INDEX ON small_world USING hnsw (v) WITH (dim=3);
 SELECT _lantern_internal.validate_index('small_world_v_idx', false);
 
@@ -21,6 +27,8 @@ INSERT INTO small_world (v) VALUES (NULL);
 
 -- Attempt to insert a row with an incorrect vector length
 \set ON_ERROR_STOP off
+-- Cannot create an hnsw index with implicit typecasts (trying to cast integer[] to real[], in this case)
+CREATE INDEX ON small_world_int USING hnsw (v dist_l2sq_ops) WITH (dim=3);
 INSERT INTO small_world (v) VALUES ('{1,1,1,1}');
 \set ON_ERROR_STOP on
 

--- a/test/sql/hnsw_vector.sql
+++ b/test/sql/hnsw_vector.sql
@@ -144,12 +144,3 @@ FROM small_world ORDER BY v <=> '[0,1,0]'::VECTOR LIMIT 7;
 
 EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <=> '[0,1,0]'::VECTOR LIMIT 7;
-
--- hamming index
-CREATE INDEX hamming_idx ON small_world  USING lantern_hnsw (v dist_vec_hamming_ops);
-
-SELECT ROUND((v <+> '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <+> '[0,1,0]'::VECTOR LIMIT 7;
-
-EXPLAIN (COSTS FALSE) SELECT ROUND((v <+> '[0,1,0]'::VECTOR)::numeric, 2) as dist
-FROM small_world ORDER BY v <+> '[0,1,0]'::VECTOR LIMIT 7;


### PR DESCRIPTION
We need properly copy and cast array elements when int array is bassed and we need floats.
Previusly we were interpreting float* array as an int32* array when calculating distances.

I think this issue does not exist when creating an index since there casts happen before. I also added a test to demonstrate this (was it already tested elsewhere and I missed it?). If you can think of other edge cases, let me know here.

The added tests check operator output when used directly. Below is the diff if I ran the same tests without the bugfix:

```diff
@@ -33,7 +33,7 @@
 SELECT ARRAY[0,0,0] <-> ARRAY[2,3,-4];
  ?column?
 ----------
-       29
+      NaN
 (1 row)

 -- with float arrays:
@@ -52,7 +52,7 @@
 SELECT '{1,0,1}' <-> '{0,1,0}'::integer[];
  ?column?
 ----------
-        3
+        0
 (1 row)

 SELECT '{1,0,1}' <=> '{0,1,0}'::integer[];
```