### PR TITLE
Add fallback mechanism for external index when reindexing

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -439,11 +439,11 @@ static bool IsExternalIndex(Relation index, HnswBuildState *buildstate, usearch_
 
         if(!index_options->m || !index_options->ef || !index_options->ef_construction) {
             ereport(ERROR,
-                    errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                    errmsg("Invalid index file path. "
-                           "If this is REINDEX operation you should drop and recreate this index"),
-                    errhint("Pass index options (dim, m, ef, ef_construction) when using "
-                            "'_experimental_index_file_path' to fallback to local index creation"));
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("Invalid index file path. "
+                            "If this is REINDEX operation you should drop and recreate this index"),
+                     errhint("Pass index options (dim, m, ef, ef_construction) when using "
+                             "'_experimental_index_file_path' to fallback to local index creation")));
         }
         elog(INFO, "index file not found, creating index locally");
         return false;

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -50,21 +50,21 @@ int ldb_HnswGetDim(Relation index)
 int ldb_HnswGetM(Relation index)
 {
     ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
-    if(opts) return opts->m;
+    if(opts && opts->m) return opts->m;
     return HNSW_DEFAULT_M;
 }
 
 int ldb_HnswGetEfConstruction(Relation index)
 {
     ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
-    if(opts) return opts->ef_construction;
+    if(opts && opts->ef_construction) return opts->ef_construction;
     return HNSW_DEFAULT_EF_CONSTRUCTION;
 }
 
 int ldb_HnswGetEf(Relation index)
 {
     ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
-    if(opts) return opts->ef;
+    if(opts && opts->ef) return opts->ef;
     return HNSW_DEFAULT_EF;
 }
 
@@ -178,7 +178,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "m",
                       "HNSW M hyperparameter",
-                      HNSW_DEFAULT_M,
+                      NULL,
                       2,
                       HNSW_MAX_M
 #if PG_VERSION_NUM >= 130000
@@ -189,7 +189,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "ef_construction",
                       "HNSW ef-construction hyperparameter",
-                      HNSW_DEFAULT_EF_CONSTRUCTION,
+                      NULL,
                       1,
                       HNSW_MAX_EF_CONSTRUCTION
 #if PG_VERSION_NUM >= 130000
@@ -201,7 +201,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "ef",
                       "HNSW ef-search hyperparameter",
-                      HNSW_DEFAULT_EF,
+                      NULL,
                       1,
                       HNSW_MAX_EF
 #if PG_VERSION_NUM >= 130000

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -178,7 +178,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "m",
                       "HNSW M hyperparameter",
-                      NULL,
+                      0,
                       2,
                       HNSW_MAX_M
 #if PG_VERSION_NUM >= 130000
@@ -189,7 +189,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "ef_construction",
                       "HNSW ef-construction hyperparameter",
-                      NULL,
+                      0,
                       1,
                       HNSW_MAX_EF_CONSTRUCTION
 #if PG_VERSION_NUM >= 130000
@@ -201,7 +201,7 @@ void _PG_init(void)
     add_int_reloption(ldb_hnsw_index_withopts,
                       "ef",
                       "HNSW ef-search hyperparameter",
-                      NULL,
+                      0,
                       1,
                       HNSW_MAX_EF
 #if PG_VERSION_NUM >= 130000

--- a/test/c/runner.c
+++ b/test/c/runner.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 // Include your test files here
+#include "test_external_index_reindex.c"
 #include "test_op_rewrite.c"
 // ===========================
 
@@ -100,7 +101,8 @@ int main()
     struct TestCase current_case;
     struct TestCase test_cases[] = {
         // Add new test files here to be run
-        {.name = "test_op_rewrite", .func = (TestCaseFunction)test_op_rewrite}
+        {.name = "test_op_rewrite", .func = (TestCaseFunction)test_op_rewrite},
+        {.name = "test_external_index_reindex", .func = (TestCaseFunction)test_external_index_reindex}
         // ================================
     };
 

--- a/test/c/test_external_index_reindex.c
+++ b/test/c/test_external_index_reindex.c
@@ -1,0 +1,86 @@
+#include <libpq-fe.h>
+#include <stdlib.h>
+
+int test_external_index_reindex(PGconn *conn)
+{
+    system("cp /tmp/lantern/files/index-sift1k-l2.usearch /tmp/lantern/files/index-reindex.usearch");
+
+    PGresult *res = PQexec(conn, "DROP TABLE IF EXISTS sift_base1k");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to drop table: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    PQclear(res);
+
+    res = PQexec(conn, "CREATE TABLE IF NOT EXISTS sift_base1k (id SERIAL, v REAL[])");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create table: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+    PQclear(res);
+
+    res = PQexec(conn, "COPY sift_base1k (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' WITH csv;");
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to copy to table: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+    PQclear(res);
+
+    // Verify that REINDEX is not working if index params are no passed
+    // And file does not exist
+    res = PQexec(conn,
+                 "CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH "
+                 "(_experimental_index_path='/tmp/lantern/files/index-reindex.usearch');");
+
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create index: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    system("rm -f /tmp/lantern/files/index-reindex.usearch");
+    res = PQexec(conn, "REINDEX INDEX hnsw_l2_index");
+
+    if(PQresultStatus(res) == PGRES_COMMAND_OK) {
+        fprintf(stderr, "Reindex should have failed but it was successfull");
+        PQclear(res);
+        return 1;
+    }
+
+    res = PQexec(conn, "DROP INDEX hnsw_l2_index");
+
+    system("cp /tmp/lantern/files/index-sift1k-l2.usearch /tmp/lantern/files/index-reindex.usearch");
+    // Verify that REINDEX is working if index params are passed (Fallback to local index creation)
+    res = PQexec(conn,
+                 "CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH "
+                 "(_experimental_index_path='/tmp/lantern/files/index-reindex.usearch', m=16, ef=32, "
+                 "ef_construction=64, dim=128);");
+
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to create index: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    system("rm -f /tmp/lantern/files/index-reindex.usearch");
+    res = PQexec(conn, "REINDEX INDEX hnsw_l2_index");
+
+    if(PQresultStatus(res) != PGRES_COMMAND_OK) {
+        fprintf(stderr, "Failed to reindex index: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    res = PQexec(conn, "SELECT _lantern_internal.validate_index('hnsw_l2_index', false);");
+    if(PQresultStatus(res) != PGRES_TUPLES_OK) {
+        fprintf(stderr, "Failed to validate index: %s\n", PQerrorMessage(conn));
+        PQclear(res);
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -61,26 +61,6 @@ SELECT * FROM ldb_get_indexes('sift_base1k');
  hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch') | 720 kB
 (1 row)
 
-DROP INDEX hnsw_l2_index;
--- Validate that creating an index from file works with params passed
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
-INFO:  done init usearch index
-INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
-SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
-INFO:  validate_index() start for hnsw_l2_index
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-SELECT * FROM ldb_get_indexes('sift_base1k');
-   indexname   |  size  |                                                                                            indexdef                                                                                            | total_index_size 
----------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
- hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m='16', ef='32', ef_construction='64', dim='128') | 720 kB
-(1 row)
-
 SET enable_seqscan=FALSE;
 SET lantern.pgvector_compat=FALSE;
 SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
@@ -117,14 +97,14 @@ SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <?>
 -----------
       0.00
     128.00
+ 249249.00
  249285.00
  249418.00
  249457.00
  249515.00
  249589.00
  249647.00
- 249675.00
- 249695.00
+ 249652.00
 (10 rows)
 
 -- Drop and recreate table
@@ -178,6 +158,27 @@ SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <?> :
   0.26
 (10 rows)
 
+-- Validate that creating an index from file works with params passed
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+INFO:  validate_index() start for hnsw_l2_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+SELECT * FROM ldb_get_indexes('sift_base1k');
+   indexname    |  size  |                                                                                            indexdef                                                                                            | total_index_size 
+----------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_cos_index | 720 kB | CREATE INDEX hnsw_cos_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-cos.usearch')                                                 | 1440 kB
+ hnsw_l2_index  | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m='16', ef='32', ef_construction='64', dim='128') | 1440 kB
+(2 rows)
+
+DROP INDEX hnsw_l2_index;
 --- Test scenarious ---
 -----------------------------------------
 -- Case:

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -15,7 +15,7 @@ COPY sift_base1k (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' 
 -- Validate error on invalid path
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/invalid-path');
 INFO:  done init usearch index
-ERROR:  Invalid index file path 
+ERROR:  Invalid index file path. If this is REINDEX operation you should drop and recreate this index
 -- Validate error on incompatible version
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2-0.0.0.usearch');
 INFO:  done init usearch index
@@ -24,6 +24,23 @@ ERROR:  Incompatible version of index file
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2-corrupted.usearch');
 INFO:  done init usearch index
 ERROR:  Wrong MIME type!
+-- Validate that you can not pass different hnsw params defined in index file 
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=5);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+ERROR:  Index option 'm'(5) does not match with the index file option 'm'(16)
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', ef=20);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+ERROR:  Index option 'ef'(20) does not match with the index file option 'ef'(32)
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', ef_construction=30);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+ERROR:  Index option 'ef_construction'(30) does not match with the index file option 'ef_construction'(64)
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=5, ef=20, ef_construction=12);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+ERROR:  Index option 'ef'(20) does not match with the index file option 'ef'(32)
 \set ON_ERROR_STOP on
 -- Validate that creating an index from file works
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch');
@@ -42,6 +59,26 @@ SELECT * FROM ldb_get_indexes('sift_base1k');
    indexname   |  size  |                                                                   indexdef                                                                   | total_index_size 
 ---------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------+------------------
  hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch') | 720 kB
+(1 row)
+
+DROP INDEX hnsw_l2_index;
+-- Validate that creating an index from file works with params passed
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+INFO:  validate_index() start for hnsw_l2_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+SELECT * FROM ldb_get_indexes('sift_base1k');
+   indexname   |  size  |                                                                                            indexdef                                                                                            | total_index_size 
+---------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m='16', ef='32', ef_construction='64', dim='128') | 720 kB
 (1 row)
 
 SET enable_seqscan=FALSE;
@@ -80,14 +117,14 @@ SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <?>
 -----------
       0.00
     128.00
- 249249.00
  249285.00
  249418.00
  249457.00
  249515.00
  249589.00
  249647.00
- 249652.00
+ 249675.00
+ 249695.00
 (10 rows)
 
 -- Drop and recreate table

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -15,9 +15,19 @@ CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_ind
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2-0.0.0.usearch');
 -- Validate error on invalid file
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2-corrupted.usearch');
+-- Validate that you can not pass different hnsw params defined in index file 
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=5);
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', ef=20);
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', ef_construction=30);
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=5, ef=20, ef_construction=12);
 \set ON_ERROR_STOP on
 -- Validate that creating an index from file works
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch');
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+SELECT * FROM ldb_get_indexes('sift_base1k');
+DROP INDEX hnsw_l2_index;
+-- Validate that creating an index from file works with params passed
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
 SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
 SELECT * FROM ldb_get_indexes('sift_base1k');
 

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -25,12 +25,6 @@ CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_ind
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch');
 SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
 SELECT * FROM ldb_get_indexes('sift_base1k');
-DROP INDEX hnsw_l2_index;
--- Validate that creating an index from file works with params passed
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
-SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
-SELECT * FROM ldb_get_indexes('sift_base1k');
-
 SET enable_seqscan=FALSE;
 SET lantern.pgvector_compat=FALSE;
 
@@ -56,6 +50,13 @@ SELECT * FROM ldb_get_indexes('sift_base1k');
 SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
 EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <?> :'v777' LIMIT 10;
 SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+
+-- Validate that creating an index from file works with params passed
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2.usearch', m=16, ef=32, ef_construction=64, dim=128);
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+SELECT * FROM ldb_get_indexes('sift_base1k');
+DROP INDEX hnsw_l2_index;
+
 
 --- Test scenarious ---
 -----------------------------------------


### PR DESCRIPTION
## Issue
When creating external index using `_experimental_index_path` option without passing any other options we are getting error on `REINDEX` operation if the index file will not exist anymore. The ideal solution will be to trigger external function in that case and create a new external index using multicore approach.

## Description
With this PR I have added a fallback mechanism, which will check if we have provided index params required for index creation (`ef`, `ef_search`, `ef_construction`) it will use them and create index locally like regular index. This will be slow compared to external index but at least it will not fail reindexing.
I have also added checks to verify that provided options are matching the ones defined in the index file header.
I have removed the default option values from `options.c` to be able to check if they are passed or not. This will not break any existing logic as we don't rely on them anyway by using our helper functions (`ldb_HnswGetM`, `ldb_HnswGetEfConstruction`, `ldb_HnswGetEf`)