### PR TITLE
Add function to reindex indexes created externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ set (_update_files
   sql/updates/0.0.8--0.0.9.sql
   sql/updates/0.0.9--0.0.10.sql
   sql/updates/0.0.10--0.0.11.sql
+  sql/updates/0.0.11--0.0.12.sql
 )
 
 add_custom_command(

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -23,6 +23,20 @@ function setup_postgres() {
   rm -f /usr/bin/pg_config && ln -s /usr/lib/postgresql/$PG_VERSION/bin/pg_config /usr/bin/pg_config
 }
 
+function install_platform_specific_dependencies() {
+  # Currently lantern_extras binaries are only available for Linux x86_64
+  # We won't install onnxruntime as lantern_extras are used only for external index in tests
+  pushd /tmp
+    LANTERN_EXTRAS_VERSION=0.0.5
+    wget https://github.com/lanterndata/lantern_extras/releases/download/${LANTERN_EXTRAS_VERSION}/lantern-extras-${LANTERN_EXTRAS_VERSION}.tar -O lantern-extras.tar
+    tar xf lantern-extras.tar
+    pushd lantern-extras-${LANTERN_EXTRAS_VERSION}
+      make install
+    popd
+    rm -rf lantern-extras*
+  popd
+}
+
 function package_if_necessary() {
   if [ -n "$BUILD_PACKAGES" ]; then
     # Bundle debian packages

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -27,7 +27,7 @@ function install_platform_specific_dependencies() {
   # Currently lantern_extras binaries are only available for Linux x86_64
   # We won't install onnxruntime as lantern_extras are used only for external index in tests
   pushd /tmp
-    LANTERN_EXTRAS_VERSION=0.0.5
+    LANTERN_EXTRAS_VERSION=0.0.6
     wget https://github.com/lanterndata/lantern_extras/releases/download/${LANTERN_EXTRAS_VERSION}/lantern-extras-${LANTERN_EXTRAS_VERSION}.tar -O lantern-extras.tar
     tar xf lantern-extras.tar
     pushd lantern-extras-${LANTERN_EXTRAS_VERSION}

--- a/ci/scripts/build-mac.sh
+++ b/ci/scripts/build-mac.sh
@@ -18,9 +18,12 @@ function setup_postgres() {
   fi
 }
 
+function install_platform_specific_dependencies() {
+  :
+}
+
 function package_if_necessary() {
   :
-  # TODO make and publish homebrew formula
 }
 
 function cleanup_environment() {

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -76,6 +76,7 @@ setup_environment
 setup_locale_and_install_packages
 setup_postgres
 install_external_dependencies
+install_platform_specific_dependencies
 clone_or_use_source
 build_and_install
 package_if_necessary

--- a/sql/lantern.sql
+++ b/sql/lantern.sql
@@ -2,6 +2,9 @@
 CREATE FUNCTION hnsw_handler(internal) RETURNS index_am_handler
 	AS 'MODULE_PATHNAME' LANGUAGE C;
 
+CREATE FUNCTION lantern_reindex_external_index(index regclass) RETURNS VOID
+	AS 'MODULE_PATHNAME', 'lantern_reindex_external_index' LANGUAGE C STABLE STRICT PARALLEL UNSAFE;
+
 -- functions
 CREATE FUNCTION ldb_generic_dist(real[], real[]) RETURNS real
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/sql/updates/0.0.11--0.0.12.sql
+++ b/sql/updates/0.0.11--0.0.12.sql
@@ -1,0 +1,2 @@
+CREATE FUNCTION lantern_reindex_external_index (index regclass) RETURNS VOID AS 'MODULE_PATHNAME',
+'lantern_reindex_external_index' LANGUAGE C STABLE STRICT PARALLEL UNSAFE;

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -419,6 +419,14 @@ Datum       lantern_internal_continue_blockmap_group_initialization(PG_FUNCTION_
     PG_RETURN_VOID();
 }
 
+PGDLLEXPORT PG_FUNCTION_INFO_V1(lantern_reindex_external_index);
+Datum       lantern_reindex_external_index(PG_FUNCTION_ARGS)
+{
+    Oid indrelid = PG_GETARG_OID(0);
+    ldb_reindex_external_index(indrelid);
+    PG_RETURN_VOID();
+}
+
 /*
  * Get data type for give oid
  * */

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -34,6 +34,7 @@ PGDLLEXPORT Datum hamming_dist_with_guard(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum cos_dist(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum cos_dist_with_guard(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum vector_cos_dist(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum lantern_reindex_external_index(PG_FUNCTION_ARGS);
 
 HnswColumnType GetColumnTypeFromOid(Oid oid);
 HnswColumnType GetIndexColumnType(Relation index);

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -431,7 +431,12 @@ static void BuildIndex(
     buildstate->hnsw = NULL;
     if(buildstate->index_file_path) {
         if(access(buildstate->index_file_path, F_OK) != 0) {
-            ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Invalid index file path ")));
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("Invalid index file path. "
+                            "If this is REINDEX operation call `SELECT "
+                            "lantern_reindex_external_index('%s')` to recreate index",
+                            RelationGetRelationName(index))));
         }
         usearch_load(buildstate->usearch_index, buildstate->index_file_path, &error);
         if(error != NULL) {

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -581,7 +581,7 @@ void ldb_reindex_external_index(Oid indrelid)
     function_argtypes = buildoidvector(function_argtypes_oid, 6);
     proc_tup = SearchSysCache3(PROCNAMEARGSNSP,
                                PointerGetDatum("_reindex_external_index"),
-                               function_argtypes,
+                               PointerGetDatum(function_argtypes),
                                ObjectIdGetDatum(lantern_extras_schema_oid));
 
     if(!HeapTupleIsValid(proc_tup)) {

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -37,5 +37,6 @@ IndexBuildResult *ldb_ambuild(Relation heap, Relation index, IndexInfo *indexInf
 void              ldb_ambuildunlogged(Relation index);
 int               GetHnswIndexDimensions(Relation index, IndexInfo *indexInfo);
 void              CheckHnswIndexDimensions(Relation index, Datum arrayDatum, int deimensions);
+void              ldb_reindex_external_index(Oid indrelid);
 // todo: does this render my check unnecessary
 #endif  // LDB_HNSW_BUILD_H

--- a/test/expected/ext_relocation.out
+++ b/test/expected/ext_relocation.out
@@ -43,9 +43,10 @@ ORDER BY 1, 3, 2;
  schema1   | hamming_dist                           | schema1
  schema1   | hnsw_handler                           | schema1
  schema1   | l2sq_dist                              | schema1
+ schema1   | lantern_reindex_external_index         | schema1
  schema1   | ldb_generic_dist                       | schema1
  schema1   | ldb_generic_dist                       | schema1
-(11 rows)
+(12 rows)
 
 -- show all the extension operators
 SELECT ne.nspname AS extschema, op.oprname, np.nspname AS proschema

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -18,6 +18,10 @@ SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10
 ERROR:  ef_construction should be in range [1, 400]
 SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
 ERROR:  ef should be in range [1, 400]
+-- Validate error on empty table
+CREATE TABLE empty (v REAL[]);
+SELECT lantern_create_external_index('v', 'empty');
+ERROR:  Can not create external index on empty table
 \set ON_ERROR_STOP on
 -- Create with defaults
 SELECT lantern_create_external_index('v', 'sift_base1k');

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -21,7 +21,7 @@ ERROR:  ef should be in range [1, 400]
 -- Validate error on empty table
 CREATE TABLE empty (v REAL[]);
 SELECT lantern_create_external_index('v', 'empty');
-ERROR:  Can not create external index on empty table
+ERROR:  Cannot create an external index on empty table
 \set ON_ERROR_STOP on
 -- Create with defaults
 SELECT lantern_create_external_index('v', 'sift_base1k');

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -1,0 +1,67 @@
+------------------------------------------------------------------------------
+-- Test Functions exported from lantern_extras extension
+------------------------------------------------------------------------------
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+\set ON_ERROR_STOP off
+CREATE EXTENSION lantern_extras;
+-- Validate error on invalid params
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'invalid_metric',  3, 10, 10, 10);
+ERROR:  Invalid metric invalid_metric
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, -1, 10, 10);
+ERROR:  m should be in range [2, 128]
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, -2, 10);
+ERROR:  ef_construction should be in range [1, 400]
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
+ERROR:  ef should be in range [1, 400]
+\set ON_ERROR_STOP on
+-- Create with defaults
+SELECT lantern_create_external_index('v', 'sift_base1k');
+ lantern_create_external_index 
+-------------------------------
+ 
+(1 row)
+
+SELECT _lantern_internal.validate_index('sift_base1k_v_idx', false);
+INFO:  validate_index() start for sift_base1k_v_idx
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+DROP INDEX sift_base1k_v_idx;
+-- Create with params
+SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'l2sq', 128, 10, 10, 10, 'hnsw_l2_index');
+ lantern_create_external_index 
+-------------------------------
+ 
+(1 row)
+
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+INFO:  validate_index() start for hnsw_l2_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+-- Reindex external index
+SELECT lantern_reindex_external_index('hnsw_l2_index');
+ lantern_reindex_external_index 
+--------------------------------
+ 
+(1 row)
+
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+INFO:  validate_index() start for hnsw_l2_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -183,3 +183,6 @@ SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <?> 
  132813.00
 (10 rows)
 
+-- Should throw error when lantern_extras is not installed
+SELECT lantern_reindex_external_index('hnsw_l2_index');
+ERROR:  Please install 'lantern_extras' extension or update it to the latest version

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -15,7 +15,7 @@ COPY sift_base1k (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' 
 -- Validate error on invalid path
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/invalid-path');
 INFO:  done init usearch index
-ERROR:  Invalid index file path 
+ERROR:  Invalid index file path. If this is REINDEX operation call `SELECT lantern_reindex_external_index('hnsw_l2_index')` to recreate index
 -- Validate error on incompatible version
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lantern/files/index-sift1k-l2-0.0.0.usearch');
 INFO:  done init usearch index

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -5,3 +5,4 @@
 
 test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate ext_relocation hnsw_ef_search hnsw_failure_point hnsw_operators hnsw_blockmap_create
 test_pgvector: hnsw_vector
+test_extras: hnsw_extras

--- a/test/sql/hnsw_extras.sql
+++ b/test/sql/hnsw_extras.sql
@@ -11,6 +11,10 @@ SELECT lantern_create_external_index('v','sift_base1k', 'public', 'invalid_metri
 SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, -1, 10, 10);
 SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, -2, 10);
 SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
+
+-- Validate error on empty table
+CREATE TABLE empty (v REAL[]);
+SELECT lantern_create_external_index('v', 'empty');
 \set ON_ERROR_STOP on
 
 -- Create with defaults

--- a/test/sql/hnsw_extras.sql
+++ b/test/sql/hnsw_extras.sql
@@ -1,0 +1,27 @@
+------------------------------------------------------------------------------
+-- Test Functions exported from lantern_extras extension
+------------------------------------------------------------------------------
+
+\ir utils/sift1k_array.sql
+
+\set ON_ERROR_STOP off
+CREATE EXTENSION lantern_extras;
+-- Validate error on invalid params
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'invalid_metric',  3, 10, 10, 10);
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, -1, 10, 10);
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, -2, 10);
+SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
+\set ON_ERROR_STOP on
+
+-- Create with defaults
+SELECT lantern_create_external_index('v', 'sift_base1k');
+SELECT _lantern_internal.validate_index('sift_base1k_v_idx', false);
+DROP INDEX sift_base1k_v_idx;
+
+-- Create with params
+SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'l2sq', 128, 10, 10, 10, 'hnsw_l2_index');
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+
+-- Reindex external index
+SELECT lantern_reindex_external_index('hnsw_l2_index');
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -61,3 +61,6 @@ CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_ind
 SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
 -- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+
+-- Should throw error when lantern_extras is not installed
+SELECT lantern_reindex_external_index('hnsw_l2_index');


### PR DESCRIPTION
- Add `lantern_reindex_external_index` function which will get the function pointer from lantern_extras `_lantern_reindex_external_index` function and call it passing the index params got from index header
- Corresponding PR in lantern_extras https://github.com/lanterndata/lantern_extras/pull/49
- Add new tests for lantern_extras function, we will install lantern extras in Linux platforms and run the tests if extension is installed. It will test the external index creation and reindexing
- Throw error on BuildIndex if index file does not exists and say to use `lantern_reindex_external_index` function  #247
