### PR TITLE
mmap index file to memory to reduce memory usage

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -496,8 +496,9 @@ static void BuildIndex(
     assert(error == NULL);
 
     if(buildstate->index_file_path == NULL) {
-        index_file_path = palloc0(sizeof("/tmp/ldb-index-.bin") + sizeof(index->rd_rel->relname.data) + 1);
-        sprintf(index_file_path, "/tmp/ldb-index-%s.bin", index->rd_rel->relname.data);
+        // size of static name + max digits of uint32 (Oid) + 1 for nullbyte
+        index_file_path = palloc0(sizeof("/tmp/ldb-index-.bin") + 10 + 1);
+        sprintf(index_file_path, "/tmp/ldb-index-%d.bin", index->rd_rel->relfilenode);
         usearch_save(buildstate->usearch_index, index_file_path, NULL, &error);
         assert(error == NULL);
     } else {

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -504,7 +504,7 @@ static void BuildIndex(
         // Filename is /tmp/ldb-index-$relfilenode.bin
         // The file will be removed in the end
         tmp_index_file_path = palloc0(tmp_index_file_char_cnt);
-        sprintf(tmp_index_file_path, tmp_index_file_fmt_str, index->rd_rel->relfilenode);
+        snprintf(tmp_index_file_path, tmp_index_file_char_cnt, tmp_index_file_fmt_str, index->rd_rel->relfilenode);
         usearch_save(buildstate->usearch_index, tmp_index_file_path, NULL, &error);
         assert(error == NULL);
         index_file_fd = open(tmp_index_file_path, O_RDONLY);

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -423,6 +423,7 @@ static void BuildIndex(
     // size of static name + max digits of uint32 (Oid) 10 + 1 for nullbyte and - 2 for %d format specifier
     const uint32       tmp_index_file_char_cnt = strlen(tmp_index_file_fmt_str) + 9;
     int                index_file_fd;
+    int                munmap_ret = 0;
     usearch_metadata_t metadata;
     size_t             num_added_vectors;
 
@@ -532,7 +533,8 @@ static void BuildIndex(
     StoreExternalIndex(index, &metadata, forkNum, result_buf, &opts, num_added_vectors);
     //****************************** saving to WAL END ******************************//
 
-    assert(munmap(result_buf, index_file_stat.st_size) == 0);
+    munmap_ret = munmap(result_buf, index_file_stat.st_size);
+    assert(munmap_ret == 0);
     close(index_file_fd);
 
     if(tmp_index_file_path) {

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -423,7 +423,7 @@ static void BuildIndex(
     // size of static name + max digits of uint32 (Oid) 10 + 1 for nullbyte and - 2 for %d format specifier
     const uint32       tmp_index_file_char_cnt = strlen(tmp_index_file_fmt_str) + 9;
     int                index_file_fd;
-    int                munmap_ret = 0;
+    int                munmap_ret;
     usearch_metadata_t metadata;
     size_t             num_added_vectors;
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -419,7 +419,7 @@ static void BuildIndex(
     struct stat            index_file_stat;
     char                  *result_buf = NULL;
     char                  *index_file_path = NULL;
-    File                   index_file_fd;
+    int                    index_file_fd;
     usearch_metadata_t     metadata;
     size_t                 num_added_vectors;
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -535,6 +535,7 @@ static void BuildIndex(
 
     munmap_ret = munmap(result_buf, index_file_stat.st_size);
     assert(munmap_ret == 0);
+    LDB_UNUSED(munmap_ret);
     close(index_file_fd);
 
     if(tmp_index_file_path) {

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -298,7 +298,7 @@ static void ContinueBlockMapGroupInitialization(
 }
 
 void StoreExternalIndexBlockMapGroup(Relation             index,
-                                     usearch_index_t      external_index,
+                                     usearch_metadata_t  *metadata,
                                      HnswIndexHeaderPage *headerp,
                                      ForkNumber           forkNum,
                                      char                *data,
@@ -321,8 +321,7 @@ void StoreExternalIndexBlockMapGroup(Relation             index,
     BlockNumber *l_wal_retriever_block_numbers
         = palloc0(sizeof(BlockNumber) * number_of_blockmaps_in_group * HNSW_BLOCKMAP_BLOCKS_PER_PAGE);
 
-    HnswIndexTuple    *bufferpage = palloc(BLCKSZ);
-    usearch_metadata_t metadata = usearch_metadata(external_index, NULL);
+    HnswIndexTuple *bufferpage = palloc(BLCKSZ);
 
     /* Add all the vectors to the WAL */
     for(uint32 node_id = first_node_index; node_id < first_node_index + num_added_vectors;) {
@@ -364,7 +363,7 @@ void StoreExternalIndexBlockMapGroup(Relation             index,
             node = extract_node(data,
                                 *progress,
                                 dimension,
-                                &metadata,
+                                metadata,
                                 /*->>output*/ &node_size,
                                 &node_level);
             bufferpage->id = node_id;
@@ -435,7 +434,7 @@ void StoreExternalIndexBlockMapGroup(Relation             index,
 }
 
 void StoreExternalIndex(Relation                index,
-                        usearch_index_t         external_index,
+                        usearch_metadata_t     *external_index_metadata,
                         ForkNumber              forkNum,
                         char                   *data,
                         usearch_init_options_t *opts,
@@ -496,7 +495,7 @@ void StoreExternalIndex(Relation                index,
     uint32   batch_size = HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
     while(num_added_vectors_remaining > 0) {
         StoreExternalIndexBlockMapGroup(index,
-                                        external_index,
+                                        external_index_metadata,
                                         headerp,
                                         forkNum,
                                         data,

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -123,7 +123,7 @@ typedef struct
 
 uint32 UsearchNodeBytes(usearch_metadata_t *metadata, int vector_bytes, int level);
 void   StoreExternalIndex(Relation                index,
-                          usearch_index_t         external_index,
+                          usearch_metadata_t     *external_index_metadata,
                           ForkNumber              forkNum,
                           char                   *data,
                           usearch_init_options_t *opts,


### PR DESCRIPTION
Previously we were copying usearch index to provided `result_buf` after the call `usearch_save` we were consuming memory of 2x of index size and then while storing the index to postgres blocks the memory consumption was 3x of index size.
Now we will write index to a file, `mmap` that file into buffer and immediately free the `usearch_index` thus making the memory consumption at most 2x of the index size.
If the index file will be provided externally via `_experimental_index_path` option, we `mmap` that file and skip `usearch_save` step.