### PR TITLE
Stop postgres using pg_ctl to avoid race conditions

### DIFF
--- a/ci/scripts/bitnami-utils.sh
+++ b/ci/scripts/bitnami-utils.sh
@@ -856,6 +856,9 @@ crash_and_restart_postgres() {
   if [[ "$pid" != "" ]]; then
     kill -9 $pid
   fi
-
+  
+  # Be sure that postgres is stopped before starting again
+  pg_ctl stop -D $POSTGRESQL_DATA_DIR || true
+  
   postgresql_start_bg
 }

--- a/ci/scripts/run-tests-linux.sh
+++ b/ci/scripts/run-tests-linux.sh
@@ -10,7 +10,7 @@ export PGDATA=/etc/postgresql/$PG_VERSION/main
 
 function stop_current_postgres() {
   # Stop any existing processes
-  /usr/lib/postgresql/$PG_VERSION/bin/pg_ctl stop -D $PGDATA || true
+  /usr/lib/postgresql/$PG_VERSION/bin/pg_ctl stop -D $PGDATA
 }
 function wait_for_pg(){
  tries=0
@@ -78,7 +78,6 @@ function start_pg() {
     # Set port
     echo "port = 5432" >> ${PGDATA}/postgresql.conf
     # Run postgres database
-    stop_current_postgres && \
     GCOV_PREFIX=$WORKDIR/build/CMakeFiles/lantern.dir/ GCOV_PREFIX_STRIP=5 POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres 1>/tmp/pg-out.log 2>/tmp/pg-error.log &
   fi
 }

--- a/ci/scripts/run-tests-linux.sh
+++ b/ci/scripts/run-tests-linux.sh
@@ -8,6 +8,10 @@ RUN_TESTS=${RUN_TESTS:-1}
 
 export PGDATA=/etc/postgresql/$PG_VERSION/main
 
+function stop_current_postgres() {
+  # Stop any existing processes
+  /usr/lib/postgresql/$PG_VERSION/bin/pg_ctl stop -D $PGDATA || true
+}
 function wait_for_pg(){
  tries=0
  until pg_isready -U postgres 2>/dev/null; do
@@ -49,10 +53,8 @@ function run_db_tests(){
     make test && \
     make test-client && \
     run_pgvector_tests
-    pg_pid=$(fuser -a 5432/tcp 2>/dev/null | awk "{print $1}" | awk '{$1=$1};1')
-    if [[ ! -z "$pg_pid" ]]; then
-      kill -9 $pg_pid
-    fi
+
+    stop_current_postgres && \
     gcovr -r $WORKDIR/src/ --object-directory $WORKDIR/build/ --xml /tmp/coverage.xml
   fi
 }
@@ -67,7 +69,6 @@ function start_pg() {
     sleep 1
     start_pg
   else
-    echo "port = 5432" >> ${PGDATA}/postgresql.conf
     # Enable auth without password
     echo "local   all             all                                     trust" >  $PGDATA/pg_hba.conf
     echo "host    all             all             127.0.0.1/32            trust" >>  $PGDATA/pg_hba.conf
@@ -77,10 +78,12 @@ function start_pg() {
     # Set port
     echo "port = 5432" >> ${PGDATA}/postgresql.conf
     # Run postgres database
+    stop_current_postgres && \
     GCOV_PREFIX=$WORKDIR/build/CMakeFiles/lantern.dir/ GCOV_PREFIX_STRIP=5 POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres 1>/tmp/pg-out.log 2>/tmp/pg-error.log &
   fi
 }
 # Wait for start and run tests
+cd /tmp
 start_pg && wait_for_pg && run_db_tests
 
 if [[ "$RUN_REPLICA_TESTS" == "1" ]]

--- a/scripts/test_updates.py
+++ b/scripts/test_updates.py
@@ -136,14 +136,16 @@ if __name__ == "__main__":
     from_tags = list(sorted([p[0] for p in tag_pairs], key=cmp_to_key(sort_versions)))
     from_tags.reverse()
     to_tags = list(sorted([p[1] for p in tag_pairs], key=cmp_to_key(sort_versions)))
-    latest_version = to_tags[-1]
-    print("Updating from tags", from_tags, "to ", latest_version)
+    
+    if len(to_tags) > 0:
+        latest_version = to_tags[-1]
+        print("Updating from tags", from_tags, "to ", latest_version)
 
-    pg_version = None if not 'PG_VERSION' in os.environ else os.environ['PG_VERSION']
-    for from_tag in from_tags:
-        if incompatible_version(pg_version, from_tag):
-            continue
-        update_from_tag(from_tag, latest_version)
+        pg_version = None if not 'PG_VERSION' in os.environ else os.environ['PG_VERSION']
+        for from_tag in from_tags:
+            if incompatible_version(pg_version, from_tag):
+                continue
+            update_from_tag(from_tag, latest_version)
 
 
 


### PR DESCRIPTION
There were 2 issues:
1. `pg_isready` was getting permissions issue when running from /home/runner/work/lantern/lantern (`pg_response could not change directory to "/home/runner/work/lantern/lantern": Permission denied`) . So I am changing directory to `/tmp` before running it.
2. When just killing postgres process via PID it needs some time before completely shut down. So if we kill postgres and immediately run again, the run might fail because some filesystem locks. Now we will stop postgres using `pg_ctl` which will wait for the process to completely stop before returning