### PR TITLE
Fixed bug where SQL query in version match check would execute outside of an outer snapshot or portal

### DIFF
--- a/test/expected/missing_outer_snapshot_portal.out
+++ b/test/expected/missing_outer_snapshot_portal.out
@@ -18,14 +18,14 @@ SET parallel_setup_cost TO 10;
 SET parallel_tuple_cost TO 0.001;
 SET seq_page_cost TO 10; 
 -- This query should have a parallel plan
-EXPLAIN SELECT COUNT(*) FROM ourtable;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=7443.79..7443.80 rows=1 width=8)
-   ->  Gather  (cost=7443.76..7443.78 rows=4 width=8)
+EXPLAIN (COSTS false) SELECT COUNT(*) FROM ourtable;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 4
-         ->  Partial Aggregate  (cost=7433.76..7433.77 rows=1 width=8)
-               ->  Parallel Seq Scan on ourtable  (cost=0.00..7377.01 rows=22701 width=0)
+         ->  Partial Aggregate
+               ->  Parallel Seq Scan on ourtable
 (5 rows)
 
 SELECT COUNT(*) FROM ourtable;

--- a/test/expected/missing_outer_snapshot_portal.out
+++ b/test/expected/missing_outer_snapshot_portal.out
@@ -1,0 +1,36 @@
+-- This test is to check that Lantern properly handles missing outer snapshots or portals when it is loaded
+-- So far, this test checks that Lantern handles cases of initializing parallel workers properly.
+-- Specifically, we test that Lantern performs the version match check by only performing its initialization SQL queries when a proper outer snapshot or portal exists. 
+-- This is to prevent the following error: "ERROR:  cannot execute SQL without an outer snapshot or portal"
+-- Note: Dropping and loading the extension again is necessary to test the desired missing outer snapshot/portal behavior
+DROP EXTENSION lantern;
+CREATE EXTENSION lantern;
+CREATE TABLE IF NOT EXISTS ourtable (
+     id SERIAL,
+     v REAL[128]
+);
+\copy ourtable (v) FROM '/tmp/lantern/vector_datasets/siftsmall_base_arrays.csv' with csv;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+--- Make parallel plans more favorable ---
+SET min_parallel_table_scan_size TO '8kB';
+SET parallel_setup_cost TO 10;
+SET parallel_tuple_cost TO 0.001;
+SET seq_page_cost TO 10; 
+-- This query should have a parallel plan
+EXPLAIN SELECT COUNT(*) FROM ourtable;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=7443.79..7443.80 rows=1 width=8)
+   ->  Gather  (cost=7443.76..7443.78 rows=4 width=8)
+         Workers Planned: 4
+         ->  Partial Aggregate  (cost=7433.76..7433.77 rows=1 width=8)
+               ->  Parallel Seq Scan on ourtable  (cost=0.00..7377.01 rows=22701 width=0)
+(5 rows)
+
+SELECT COUNT(*) FROM ourtable;
+ count 
+-------
+ 10000
+(1 row)
+

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -3,6 +3,6 @@
 # - every test that needs to be run iff pgvector is installed appears in a 'test_pgvector:' line
 # - 'test' lines may have multiple space-separated tests. All tests in a single 'test' line will be run in parallel
 
-test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate ext_relocation hnsw_ef_search hnsw_failure_point hnsw_operators hnsw_blockmap_create hnsw_create_unlogged hnsw_insert_unlogged hnsw_logged_unlogged
+test: hnsw_config hnsw_correct hnsw_create hnsw_create_expr hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file hnsw_cost_estimate ext_relocation hnsw_ef_search hnsw_failure_point hnsw_operators hnsw_blockmap_create hnsw_create_unlogged hnsw_insert_unlogged hnsw_logged_unlogged missing_outer_snapshot_portal
 test_pgvector: hnsw_vector
 test_extras: hnsw_extras

--- a/test/sql/missing_outer_snapshot_portal.sql
+++ b/test/sql/missing_outer_snapshot_portal.sql
@@ -1,0 +1,33 @@
+-- This test is to check that Lantern properly handles missing outer snapshots or portals when it is loaded
+
+-- So far, this test checks that Lantern handles cases of initializing parallel workers properly.
+-- Specifically, we test that Lantern performs the version match check by only performing its initialization SQL queries when a proper outer snapshot or portal exists. 
+-- This is to prevent the following error: "ERROR:  cannot execute SQL without an outer snapshot or portal"
+
+-- Note: Dropping and loading the extension again is necessary to test the desired missing outer snapshot/portal behavior
+DROP EXTENSION lantern;
+CREATE EXTENSION lantern;
+
+CREATE TABLE IF NOT EXISTS ourtable (
+     id SERIAL,
+     v REAL[128]
+);
+
+\copy ourtable (v) FROM '/tmp/lantern/vector_datasets/siftsmall_base_arrays.csv' with csv;
+
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+
+--- Make parallel plans more favorable ---
+SET min_parallel_table_scan_size TO '8kB';
+
+SET parallel_setup_cost TO 10;
+SET parallel_tuple_cost TO 0.001;
+
+SET seq_page_cost TO 10; 
+
+-- This query should have a parallel plan
+EXPLAIN SELECT COUNT(*) FROM ourtable;
+SELECT COUNT(*) FROM ourtable;
+
+

--- a/test/sql/missing_outer_snapshot_portal.sql
+++ b/test/sql/missing_outer_snapshot_portal.sql
@@ -27,7 +27,7 @@ SET parallel_tuple_cost TO 0.001;
 SET seq_page_cost TO 10; 
 
 -- This query should have a parallel plan
-EXPLAIN SELECT COUNT(*) FROM ourtable;
+EXPLAIN (COSTS false) SELECT COUNT(*) FROM ourtable;
 SELECT COUNT(*) FROM ourtable;
 
 


### PR DESCRIPTION
Came across the following bug:

### Bug Replication

To replicate the original bug, comment out the changes in `utils.c`:

```C
   // comment this out
    if(!ActiveSnapshotSet()) {
        version_checked = versions_match = false;
        return true;
    }
```
and run the added test: `make test FILTER=missing_outer_snapshot_portal`.

Without the proposed changes, we would have gotten the error `ERROR:  cannot execute SQL without an outer snapshot or portal` after running a simple `SELECT COUNT(*) FROM` query.

It appears that this bug is caused by queries that launch parallel workers in their execution plan. The first/parent worker is able to run this version check just fine, but future workers spawn in with no outer snapshot and when `_PG_init` eventually invokes `VersionsMatch`, the  SQL query where we fetch the lantern version in this function fails because there is no outer snapshot.

### Solution

Before executing any SQL in `VersionsMatch`, we check if an active snapshot exists. If one doesn't, we return true instead of executing the SQL (which would error) and postpone actually checking to any future calls of this function. Note that we return true because the idea is that `VersionsMatch` will have ran already by the time future parallel workers are spawned, and so in the event of a version mismatch any warnings would have been processed by callers of `VersionsMatch` on the original/parent worker. So, on parallel workers, we return true just to suppress any additional warnings by these same callers (like `_PG_init`, or when scanning/inserting into our index). An alternative approach to this is to return status codes (like `CONFIRMED_MISMATCH`, `CONFIRMED_MATCH`, and `UNCONFIRMED`) and edit error handling appropriately. 

Another possible alternative fix would be to fetch a snapshot and inject it in the context so that the SQL query can run regardless, but given that this is doing duplicated work anyway (that is, I don't think version mismatches across parallel workers is not possible, so checking on the parent is enough) I opted for the above since this alternative would increase overhead.

### Notes
Why do we have to `DROP` and `CREATE` the extension again in the test to get this bug? Without these lines, the original bug isn't present. What is it about our testing infra that gets Postgres to skip `_PG_init` (and hence, skip `VersionsMatch`) when spawning parallel workers on queries later?