### PR TITLE
Emit LLVM bitcode and copy to postgres if JIT is available #258

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,26 @@ if (${LANTERNDB_COPYNODES})
 endif()
 
 set(_script_file "lantern--${RELEASE_ID}.sql")
+
+# ============== Use clang compiler to emit llvm bytecode =================
+find_program(LLVM_LTO NAMES llvm-lto)
+if(
+  NOT LLVM_LTO STREQUAL "LLVM_LTO-NOTFOUND" 
+  AND PostgreSQL_WITH_LLVM 
+  AND CMAKE_C_COMPILER_ID MATCHES "Clang" 
+  AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+)
+  target_link_options(lantern PRIVATE -flto)
+  target_compile_options(lantern PRIVATE  "-emit-llvm")
+  add_custom_target(link_llvm_objects ALL
+      DEPENDS lantern
+      COMMAND ${CMAKE_SOURCE_DIR}/scripts/link_llvm_objects.sh '$<TARGET_OBJECTS:lantern>' ${CMAKE_BINARY_DIR}
+  )
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/bitcode/ DESTINATION ${PostgreSQL_PACKAGE_LIBRARY_DIR}/bitcode)
+  message(STATUS "Using clang compiler to emit llvm bytecode")
+endif()
+# =========================================================================
+
 set (_update_files
   sql/updates/0.0.5--0.0.6.sql
   sql/updates/0.0.6--0.0.7.sql
@@ -262,8 +282,6 @@ set(CONTROL_TEMPLATE "${CMAKE_MODULE_PATH}/lantern.control.template")
 set(CONTROL_OUTPUT "${CMAKE_BINARY_DIR}/lantern.control")
 configure_file(${CONTROL_TEMPLATE} ${CONTROL_OUTPUT})
 
-
-# INSTALL
 install(TARGETS lantern LIBRARY DESTINATION ${PostgreSQL_PACKAGE_LIBRARY_DIR})
 install(FILES ${CONTROL_OUTPUT} ${CMAKE_BINARY_DIR}/${_script_file}
         DESTINATION ${PostgreSQL_EXTENSION_DIR})

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /tmp/lantern
 
 COPY . .
 
-RUN PG_VERSION=$PG_VERSION ./ci/scripts/build-docker.sh 
+RUN PG_VERSION=$PG_VERSION ./ci/scripts/build-docker.sh

--- a/ci/scripts/build-docker.sh
+++ b/ci/scripts/build-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_cmake_flags(){
- echo "-DBUILD_FOR_DISTRIBUTING=YES -DMARCH_NATIVE=OFF"
+ echo "-DBUILD_FOR_DISTRIBUTING=YES -DMARCH_NATIVE=OFF -DCMAKE_C_COMPILER=clang  -DCMAKE_CXX_COMPILER=clang"
 }
 
 export DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,7 @@ fi
 # Set Locale
 apt update && apt-mark hold locales && \
 # Install required packages for build
-apt install -y --no-install-recommends build-essential cmake postgresql-server-dev-$PG_VERSION && \
+apt install -y --no-install-recommends build-essential cmake clang llvm postgresql-server-dev-$PG_VERSION && \
 # Build lantern
 cd /tmp/lantern && mkdir build && cd build && \
 # Run cmake
@@ -22,7 +22,7 @@ sh -c "cmake $(get_cmake_flags) .." && \
 make install && \
 # Remove dev files
 rm -rf /tmp/lantern && \
-apt-get remove -y build-essential postgresql-server-dev-$PG_VERSION cmake && \
+apt-get remove -y build-essential postgresql-server-dev-$PG_VERSION cmake clang llvm && \
 apt-get autoremove -y && \
 apt-mark unhold locales && \
 rm -rf /var/lib/apt/lists/*

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -7,7 +7,7 @@ function setup_locale_and_install_packages() {
   echo "LANG=en_US.UTF-8" > /etc/locale.conf
 
   apt update -y
-  apt install -y locales lsb-core build-essential automake cmake wget git dpkg-dev lcov clang-format
+  apt install -y locales lsb-core build-essential automake cmake wget git dpkg-dev lcov clang-format clang llvm
 
   locale-gen en_US.UTF-8
 }

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -58,10 +58,11 @@ function build_and_install() {
   
   # Treat warnings as errors in CI/CD
   flags+=" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+  flags+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang"
   
   if [ -n "$ENABLE_COVERAGE" ]
   then
-    flags="$flags -DCMAKE_C_COMPILER=/usr/bin/gcc -DCODECOVERAGE=ON -DBUILD_C_TESTS=ON"
+    flags="$flags -DCODECOVERAGE=ON -DBUILD_C_TESTS=ON"
   fi
 
   # Run cmake

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -58,11 +58,12 @@ function build_and_install() {
   
   # Treat warnings as errors in CI/CD
   flags+=" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-  flags+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang"
   
   if [ -n "$ENABLE_COVERAGE" ]
   then
-    flags="$flags -DCODECOVERAGE=ON -DBUILD_C_TESTS=ON"
+    flags="$flags -DCMAKE_C_COMPILER=/usr/bin/gcc -DCODECOVERAGE=ON -DBUILD_C_TESTS=ON"
+  else
+    flags+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang"
   fi
 
   # Run cmake

--- a/ci/scripts/universal-package.sh
+++ b/ci/scripts/universal-package.sh
@@ -34,6 +34,7 @@ for f in $(find "." -name "*.tar"); do
 
     mkdir -p $current_dest_folder
     cp $current_archive_name/src/*.{so,dylib} $current_dest_folder/ 2>/dev/null || true
+    cp -r $current_archive_name/bitcode $current_dest_folder/bitcode 2>/dev/null || true
 done
 
 if [ ! -z "$PACKAGE_EXTRAS" ]

--- a/ci/scripts/universal-package.sh
+++ b/ci/scripts/universal-package.sh
@@ -34,7 +34,7 @@ for f in $(find "." -name "*.tar"); do
 
     mkdir -p $current_dest_folder
     cp $current_archive_name/src/*.{so,dylib} $current_dest_folder/ 2>/dev/null || true
-    cp -r $current_archive_name/bitcode $current_dest_folder/bitcode 2>/dev/null || true
+    cp -r $current_archive_name/src/bitcode $current_dest_folder/ 2>/dev/null || true
 done
 
 if [ ! -z "$PACKAGE_EXTRAS" ]

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -85,6 +85,7 @@ if(PostgreSQL_FOUND)
   pg_config(_pg_pkglibdir --pkglibdir)
   pg_config(_pg_libdir --libdir)
   pg_config(_pg_version --version)
+  pg_config(_pg_compileflags --configure)
 
   separate_arguments(_pg_ldflags)
   separate_arguments(_pg_ldflags_sl)
@@ -94,9 +95,19 @@ if(PostgreSQL_FOUND)
   set(_server_inc_dirs ${_pg_includedir_server} ${_pg_pkgincludedir})
   string(REPLACE ";" " " _shared_link_options
                  "${_pg_ldflags};${_pg_ldflags_sl}")
+
+
   set(_link_options ${_pg_ldflags})
   if(_pg_ldflags_ex)
     list(APPEND _link_options ${_pg_ldflags_ex})
+  endif()
+
+  string(FIND ${_pg_compileflags} "--with-llvm" _pg_with_llvm_idx)
+
+  if(${_pg_with_llvm_idx} EQUAL -1)
+	  set(_pg_with_llvm FALSE)
+  else()
+	  set(_pg_with_llvm TRUE)
   endif()
 
   set(PostgreSQL_INCLUDE_DIRS
@@ -131,6 +142,9 @@ if(PostgreSQL_FOUND)
   set(PostgreSQL_PACKAGE_LIBRARY_DIR
       "${_pg_pkglibdir}"
       CACHE STRING "PostgreSQL package library directory")
+  set(PostgreSQL_WITH_LLVM
+      "${_pg_with_llvm}"
+      CACHE BOOL "PostgreSQL -with-llvm flag.")
 
   find_program(
     PG_BINARY postgres

--- a/scripts/link_llvm_objects.sh
+++ b/scripts/link_llvm_objects.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+BC_FILES=""
+
+if [ $# -lt 2 ]
+  then
+      echo "Usage: link_llvm_objects.sh 'obj1.o;obj2.o;obj3.o' /abs/path/to/build_dir"
+    exit 1
+fi
+
+bitcode_dir="$2/bitcode"
+bitcode_target_dir="$bitcode_dir/lantern" 
+mkdir -p "$bitcode_target_dir"
+
+for obj in ${1//;/ } ; do 
+   # Get relative path from absolute, so we will get a path like `src/hnsw/hnsw.c.o`
+   relative_path=${obj#"$2/CMakeFiles/lantern.dir/"}
+   # Get dirname from relative path (e.g `src/hnsw`)
+   dir_part=$(dirname "$relative_path")
+   mkdir -p "$bitcode_target_dir/$dir_part"
+   # Change suffix from .o to .bc
+   obj_bc=${relative_path%.*}.bc
+   obj_bc_path="$bitcode_target_dir/$obj_bc"
+   cp $obj "$obj_bc_path"
+
+   BC_FILES="$BC_FILES lantern/$obj_bc"
+done
+
+# Link bc files into lantern.index.bc
+pushd $bitcode_dir >/dev/null
+ llvm-lto -thinlto -thinlto-action=thinlink -o $bitcode_dir/lantern.index.bc $BC_FILES
+popd >/dev/null

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -12,6 +12,7 @@ cp ${SOURCE_DIR}/scripts/packaging/* ${BUILD_DIR}/${PACKAGE_NAME}/
 # Instead of .so, so any of the files may not exist
 # So we will ignore the error from cp command
 cp ${BUILD_DIR}/*.{so,dylib} ${BUILD_DIR}/${PACKAGE_NAME}/src 2>/dev/null || true
+cp -r ${BUILD_DIR}/bitcode ${BUILD_DIR}/${PACKAGE_NAME}/bitcode 2>/dev/null || true
 cp ${BUILD_DIR}/*.sql ${BUILD_DIR}/${PACKAGE_NAME}/src
 
 for f in $(find "${SOURCE_DIR}/sql/updates/" -name "*.sql"); do

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -12,7 +12,7 @@ cp ${SOURCE_DIR}/scripts/packaging/* ${BUILD_DIR}/${PACKAGE_NAME}/
 # Instead of .so, so any of the files may not exist
 # So we will ignore the error from cp command
 cp ${BUILD_DIR}/*.{so,dylib} ${BUILD_DIR}/${PACKAGE_NAME}/src 2>/dev/null || true
-cp -r ${BUILD_DIR}/bitcode ${BUILD_DIR}/${PACKAGE_NAME}/bitcode 2>/dev/null || true
+cp -r ${BUILD_DIR}/bitcode ${BUILD_DIR}/${PACKAGE_NAME}/src/bitcode 2>/dev/null || true
 cp ${BUILD_DIR}/*.sql ${BUILD_DIR}/${PACKAGE_NAME}/src
 
 for f in $(find "${SOURCE_DIR}/sql/updates/" -name "*.sql"); do

--- a/scripts/packaging/install.sh
+++ b/scripts/packaging/install.sh
@@ -55,6 +55,7 @@ then
 fi
 
 cp -r src/${ARCH}/${PLATFORM}/${PG_VERSION}/*.{so,dylib} $PG_LIBRARY_DIR 2>/dev/null || true
+cp -r src/${ARCH}/${PLATFORM}/${PG_VERSION}/bitcode/* $PG_LIBRARY_DIR/bitcode/ 2>/dev/null || true
 cp -r shared/*.sql $PG_EXTENSION_DIR
 cp -r shared/*.control $PG_EXTENSION_DIR
 

--- a/scripts/packaging/uninstall.sh
+++ b/scripts/packaging/uninstall.sh
@@ -14,6 +14,8 @@ PG_LIBRARY_DIR=$($PG_CONFIG --pkglibdir)
 PG_EXTENSION_DIR=$($PG_CONFIG --sharedir)/extension
 
 rm -rf $PG_LIBRARY_DIR/lantern*.so
+rm -rf $PG_LIBRARY_DIR/bitcode/lantern 2> /dev/null || true
+rm -rf $PG_LIBRARY_DIR/bitcode/lantern.index.bc 2> /dev/null || true
 rm -rf $PG_EXTENSION_DIR/lantern*.sql
 rm -rf $PG_EXTENSION_DIR/lantern*.control
 


### PR DESCRIPTION
In build step we will check if the compiler is `clang` the `llvm-lto` linker is available and `Postgres` is built with `--with-llvm` flag, then emit LLVM bitcode instead `ELF` objects. Then the `link_llvm_objects` target will copy the `.o` files to `bitcode/lantern/**/.bc` and link them together into `bitcode/index.lantern.bc`. 

The install target will copy the contents of `bitcode/` directory into `$PKGLIBDIR/bitcode/`

[PGXS reference](https://github.com/postgres/postgres/blob/master/src/Makefile.global.in#L1077-L1104)
[Postgres docs](https://www.postgresql.org/docs/current/jit-extensibility.html)

Issue: #258