### PR TITLE
Always Exit with non-zero error code in error cases of install script

### DIFF
--- a/scripts/packaging/install.sh
+++ b/scripts/packaging/install.sh
@@ -5,7 +5,7 @@ then
   if ! command -v pg_config &> /dev/null
   then
     echo "pg_config could not be found. Please specify with PG_CONFIG env variable"
-    exit
+    exit 1
   fi
   PG_CONFIG=$(which pg_config)
 fi
@@ -39,31 +39,31 @@ PG_VERSION=$(echo $PG_VERSION_STRING | sed -E "s#^PostgreSQL ([0-9]+).*#\1#")
 if [ ! -d src/${ARCH} ]
 then
   echo "Architecture $ARCH not supported. Try building from source"
-  exit
+  exit 1
 fi
 
 if [ ! -d src/${ARCH}/${PLATFORM} ]
 then
   echo "Platform $PLATFORM not supported. Try building from source"
-  exit
+  exit 1
 fi
 
 if [ ! -d src/${ARCH}/${PLATFORM}/${PG_VERSION} ]
 then
   echo "Postgres version $PG_VERSION not supported"
-  exit
+  exit 1
 fi
 
 cp -r src/${ARCH}/${PLATFORM}/${PG_VERSION}/*.{so,dylib} $PG_LIBRARY_DIR 2>/dev/null || true
 cp -r shared/*.sql $PG_EXTENSION_DIR
 cp -r shared/*.control $PG_EXTENSION_DIR
 
-echo "LanternDB installed successfully"
+echo "Lantern installed successfully"
 
 EXTRAS_PACKAGE_NAME=$(find . -name "lantern-extras*" | head -n 1)
 
 if [ ! -z "$EXTRAS_PACKAGE_NAME" ]
 then
-  echo "Installing LanternDB Extras"
+  echo "Installing Lantern Extras"
   cd $EXTRAS_PACKAGE_NAME && make install
 fi

--- a/scripts/packaging/uninstall.sh
+++ b/scripts/packaging/uninstall.sh
@@ -5,7 +5,7 @@ then
   if ! command -v pg_config &> /dev/null
   then
     echo "pg_config could not be found. Please specify with PG_CONFIG env variable"
-    exit
+    exit 1
   fi
   PG_CONFIG=$(which pg_config)
 fi
@@ -17,4 +17,4 @@ rm -rf $PG_LIBRARY_DIR/lantern*.so
 rm -rf $PG_EXTENSION_DIR/lantern*.sql
 rm -rf $PG_EXTENSION_DIR/lantern*.control
 
-echo "LanternDB uninstalled successfully"
+echo "Lantern uninstalled successfully"


### PR DESCRIPTION
Without this, an installation from binary file returns zero, indicating success.
This led us believe that ARM binaries were distributed in releases when building lantern-suite in ci/cd here:
https://github.com/lanterndata/lantern-suite/actions/runs/7631627710/job/20790001102#step:6:3777