### PR TITLE
Update actions to latest version to use NodeJS 20 runtime

### DIFF
--- a/.github/workflows/benchmark-linux.yaml
+++ b/.github/workflows/benchmark-linux.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
@@ -33,14 +33,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: |
             /tmp/benchmarks-out.json
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: fc
         with:
@@ -49,7 +49,7 @@ jobs:
           body-includes: Benchmarks
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-22.04, ubicloud-standard-2-arm, macos-13]
         postgres: [11, 12, 13, 14, 15, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
       - name: Build
@@ -36,35 +36,39 @@ jobs:
         id: archive
         run: sudo sh -c "GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/package-archive.sh"
       - name: Upload deb package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ steps.build.outputs.deb_package_path != '' }}
         with:
           name: ${{ steps.build.outputs.deb_package_name }}
           path: ${{ steps.build.outputs.deb_package_path }}
       - name: Upload archive package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ steps.archive.outputs.archive_package_path != '' }}
         with:
-          name: lantern-package
+          name: ${{ steps.archive.outputs.archive_package_name }}
           path: ${{ steps.archive.outputs.archive_package_path }}
   package:
     runs-on: ubuntu-22.04
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: lantern-package
+          pattern: lantern-*.tar
+          merge-multiple: true
           path: /tmp/lantern-package
+      - uses: geekyeggo/delete-artifact@v4
+        with:
+          name: lantern-*.tar
       - name: Create universal package
         id: package
         run: sudo sh -c "GITHUB_OUTPUT=$GITHUB_OUTPUT PACKAGE_EXTRAS=1 GITHUB_TOKEN=$GITHUB_TOKEN ./ci/scripts/universal-package.sh"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.package_name }}
           path: ${{ steps.package.outputs.package_path }}
@@ -73,9 +77,6 @@ jobs:
         run: |
           find ./ -name '.git*' -exec rm -r {} \; || true
           tar -czf /tmp/lantern-v${{ steps.package.outputs.package_version }}-source.tar.gz .
-      - uses: geekyeggo/delete-artifact@v2
-        with:
-          name: lantern-package
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         id: create_release

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -31,20 +31,20 @@ jobs:
           - postgres: 12
           - postgres: 11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -88,7 +88,7 @@ jobs:
         libstdc++6
 
     - name: Checkout lantern
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: "recursive"
@@ -111,7 +111,7 @@ jobs:
     # leading to a tainted cache
     - name: Cache PostgreSQL ${{ matrix.pg }}
       id: cache-postgresql
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}\
@@ -137,7 +137,7 @@ jobs:
         echo "exit_code=$?" >> $GITHUB_OUTPUT
 
     - name: save cache preemptively if postgres built
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: steps.build-postgresql.outputs.exit_code == 0
       with:
         path: ~/${{ env.PG_SRC_DIR }}
@@ -146,7 +146,7 @@ jobs:
 
     - name: Upload config.log
       if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: config.log for PostgreSQL ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: ~/${{ env.PG_SRC_DIR }}/config.log
@@ -199,7 +199,7 @@ jobs:
 
     - name: Save regression diffs
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: |
@@ -207,7 +207,7 @@ jobs:
 
     - name: Save postgres log
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Postgres log ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: |
@@ -234,14 +234,14 @@ jobs:
 
     - name: Coredumps
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Coredumps ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: coredumps
 
     - name: sanitizer logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sanitizer logs ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: ${{ github.workspace }}/sanitizer

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-22.04, ubicloud-standard-2-arm, macos-13]
         postgres: [11, 12, 13, 14, 15, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch-depth ensures all tags are present on the repo so we can run update tests successfully
           fetch-depth: 0
@@ -66,7 +66,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'mac') }}
       - name: Upload Postgres logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: postgres-server-${{ matrix.postgres }}-logs
           path: |


### PR DESCRIPTION
Github is deprecating NodeJS 16 runtime, so actions needs to be updated to use NodeJS 20 runtime. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

The only action left is `softprops/action-gh-release` , which has an [open PR](https://github.com/softprops/action-gh-release/pull/406) to address the issue