### PR TITLE
Fixes for bugs in cost estimate function (relevant for partial indexes)

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -46,6 +46,7 @@ then
         curl -sSo sift_base1k.csv https://storage.googleapis.com/lanterndb/sift_base1k.csv
         curl -sSo siftsmall_base.csv https://storage.googleapis.com/lanterndata/siftsmall/siftsmall_base.csv
         curl -sSo tsv_wiki_sample.csv https://storage.googleapis.com/lanterndb/tsv_wiki_sample.csv
+        curl -sSo views_vec10k.csv https://storage.googleapis.com/lanterndata/random_multicolumn/views_vec10k.csv
         # Convert vector to arrays to be used with real[] type
         cat sift_base1k.csv | sed -e 's/\[/{/g' | sed -e 's/\]/}/g' > sift_base1k_arrays.csv
         cat siftsmall_base.csv | sed -e 's/\[/{/g' | sed -e 's/\]/}/g' > siftsmall_base_arrays.csv

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -171,7 +171,7 @@ static void hnswcostestimate(PlannerInfo *root,
     /* ALWAYS use index when asked*/
     MemSet(&costs, 0, sizeof(costs));
 
-    double num_tuples_in_index = path->indexinfo->rel->tuples;
+    double num_tuples_in_index = path->indexinfo->tuples;
     costs.numIndexTuples = estimate_number_tuples_accessed(path->indexinfo->indexoid, num_tuples_in_index);
     uint64 num_blocks_accessed
         = estimate_number_blocks_accessed(num_tuples_in_index, path->indexinfo->pages, costs.numIndexTuples);

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -133,7 +133,7 @@ static uint64 estimate_number_blocks_accessed(uint64 num_tuples_in_index, uint64
     // we switch away from blockmaps.
     const uint64 num_blockmaps_used = ceil(num_tuples_in_index / HNSW_BLOCKMAP_BLOCKS_PER_PAGE);
     const uint64 num_blockmap_allocated = pow(2, floor(log2(num_blockmaps_used)) + 1);
-    const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
+    const uint64 num_datablocks = Max((int64)num_pages - 1 - (int64)num_blockmap_allocated, 1);
 
     const uint64 num_datablocks_accessed = ((double)num_tuples_accessed / (double)num_tuples_in_index) * num_datablocks;
     const uint64 num_blockmaps_accessed

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -163,3 +163,44 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 DROP INDEX hnsw_idx;
+-- Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
+-- this is relevant in this check in estimate_number_blocks_accessed in hnsw.c:
+-- const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
+-- One place where this happens is on partial indexes where the filter is rare (empirically, matching <2.5% of the entire table)
+-- This is what we test below
+\ir utils/views_vec10k.sql
+CREATE TABLE IF NOT EXISTS views_vec10k (
+     id INTEGER,
+     views INTEGER,
+     vec REAL[]
+);
+\copy views_vec10k (id, views, vec) FROM '/tmp/lantern/vector_datasets/views_vec10k.csv' WITH (FORMAT CSV, HEADER);
+SET hnsw.init_k = 10;
+-- Note that the (views < 100) condition is quite rare (out of 10,000 rows)
+SELECT COUNT(*) FROM views_vec10k WHERE views < 100;
+ count 
+-------
+    58
+(1 row)
+
+-- Create partial lantern index with (views < 100) filter
+CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 100;
+INFO:  done init usearch index
+INFO:  inserted 58 elements
+INFO:  done saving 58 vectors
+-- This should use the partial index we just created, since it is an exact filter match
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 4.108750
+DEBUG:  LANTERN - Selectivity: 1.000000
+DEBUG:  LANTERN - Num pages: 1.000000
+DEBUG:  LANTERN - Num tuples: 58.000000
+DEBUG:  LANTERN - ---------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_100 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -192,10 +192,10 @@ INFO:  done saving 58 vectors
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 4.108750
+DEBUG:  LANTERN - Total cost: 4.071250
 DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
-DEBUG:  LANTERN - Num tuples: 58.000000
+DEBUG:  LANTERN - Num tuples: 19.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
 ---------------------------------------------------------------

--- a/test/sql/utils/views_vec10k.sql
+++ b/test/sql/utils/views_vec10k.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS views_vec10k (
+     id INTEGER,
+     views INTEGER,
+     vec REAL[]
+);
+
+\copy views_vec10k (id, views, vec) FROM '/tmp/lantern/vector_datasets/views_vec10k.csv' WITH (FORMAT CSV, HEADER);


### PR DESCRIPTION
1. There was an unsigned integer underflow bug in our cost estimation that would lead to astronomically high costs for certain partial indexes. To replicate (check out to first commit), delete the `/tmp/lantern/vector_datasets` folder (to force download of a new dataset file) and `make test`, and look at the output of the `hnsw_cost_estimate` test, at the end. The cost value for the added test case is extremely high, indicating an unsigned underflow:

```
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 25261826802294276096.000000
+DEBUG:  LANTERN - Selectivity: 1.000000
+DEBUG:  LANTERN - Num pages: 6148299799767393280.000000
+DEBUG:  LANTERN - Num tuples: 58.000000
+DEBUG:  LANTERN - ---------------------
``` 

This underflow prevents certain partial indexes from being used-- which we can see in this test as well: there is a lantern partial index, and a filtered query whose filter matches exactly that of the partial index, and so the partial index should be used but it is not (because of its extremely high cost). 

We fix this underflow (check out to second commit) by casting to signed int in the appropriate calculation.

2. We were previously using `path->indexinfo->rel->tuples` as the number of tuples in our index, but this is actually the number of tuples in the table. This is problematic when we deal with partial indexes, when the number of tuples in the index can differ significantly from the number of tuples in the table. The number of tuples in our index is given by `path->indexinfo->tuples`.

3. There is another potential unsigned integer underflow in `estimate_number_tuples_accessed` when we calculate this line:
`uint64 total_tuple_visits = tuples_visited_per_non_base_level * (expected_num_levels - 1);`. If we check that `num_tuples_in_index > 0` earlier in the function, it follows that `expected_num_levels` is always at least 1, and so we won't underflow.