### PR TITLE
Use proper index selectivity in hnswcostestimate function

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -199,13 +199,13 @@ static void hnswcostestimate(PlannerInfo *root,
     *indexCorrelation = 0;
     *indexPages = num_blocks_accessed;
 
-    ldb_tlog("LANTERN - Query cost estimator");
-    ldb_tlog("LANTERN - ---------------------");
+    ldb_dlog("LANTERN - Query cost estimator");
+    ldb_dlog("LANTERN - ---------------------");
     ldb_dlog("LANTERN - Total cost: %lf", *indexTotalCost);
-    ldb_tlog("LANTERN - Selectivity: %lf", *indexSelectivity);
+    ldb_dlog("LANTERN - Selectivity: %lf", *indexSelectivity);
     ldb_dlog("LANTERN - Num pages: %lf", *indexPages);
-    ldb_tlog("LANTERN - Num tuples: %lf", costs.numIndexTuples);
-    ldb_tlog("LANTERN - ---------------------");
+    ldb_dlog("LANTERN - Num tuples: %lf", costs.numIndexTuples);
+    ldb_dlog("LANTERN - ---------------------");
 }
 
 /*

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -187,7 +187,13 @@ static void hnswcostestimate(PlannerInfo *root,
 
     *indexStartupCost = 0;
     *indexTotalCost = costs.numIndexPages ? costs.indexTotalCost * (num_blocks_accessed / costs.numIndexPages) : 0;
-    *indexSelectivity = 1.0;
+    // indexSelectivity is the fraction of all rows in the table that our index is expected to return
+    // (https://www.postgresql.org/docs/current/index-cost-estimation.html) We are an order-by only index, and so we
+    // return all of the rows in our index. So, this is just the fraction of all rows in the table that is in the index
+    // (recall that partial indexes can exclude rows from the table), and this is what genericcostestimate computes
+    // above
+    *indexSelectivity = costs.indexSelectivity;
+
     // since we try to insert index tuples at the last datablock,
     // there is no "order" at all that can be assumed.
     *indexCorrelation = 0;

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -199,13 +199,13 @@ static void hnswcostestimate(PlannerInfo *root,
     *indexCorrelation = 0;
     *indexPages = num_blocks_accessed;
 
-    ldb_dlog("LANTERN - Query cost estimator");
-    ldb_dlog("LANTERN - ---------------------");
+    ldb_tlog("LANTERN - Query cost estimator");
+    ldb_tlog("LANTERN - ---------------------");
     ldb_dlog("LANTERN - Total cost: %lf", *indexTotalCost);
-    ldb_dlog("LANTERN - Selectivity: %lf", *indexSelectivity);
+    ldb_tlog("LANTERN - Selectivity: %lf", *indexSelectivity);
     ldb_dlog("LANTERN - Num pages: %lf", *indexPages);
-    ldb_dlog("LANTERN - Num tuples: %lf", costs.numIndexTuples);
-    ldb_dlog("LANTERN - ---------------------");
+    ldb_tlog("LANTERN - Num tuples: %lf", costs.numIndexTuples);
+    ldb_tlog("LANTERN - ---------------------");
 }
 
 /*

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -41,12 +41,4 @@ static inline void ldb_invariant(bool condition, const char *msg, ...)
         }                              \
     } while(0)
 
-// same as ldb_dlog above but intended for output in tests that needs to be consistent across systems and OS
-#define ldb_tlog(...)                  \
-    do {                               \
-        if(unlikely(ldb_is_test)) {    \
-            elog(DEBUG4, __VA_ARGS__); \
-        }                              \
-    } while(0)
-
 #endif  // LDB_HNSW_UTILS_H

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -41,4 +41,12 @@ static inline void ldb_invariant(bool condition, const char *msg, ...)
         }                              \
     } while(0)
 
+// same as ldb_dlog above but intended for output in tests that needs to be consistent across systems and OS
+#define ldb_tlog(...)                  \
+    do {                               \
+        if(unlikely(ldb_is_test)) {    \
+            elog(DEBUG4, __VA_ARGS__); \
+        }                              \
+    } while(0)
+
 #endif  // LDB_HNSW_UTILS_H

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -175,6 +175,8 @@ CREATE TABLE IF NOT EXISTS views_vec10k (
      vec REAL[]
 );
 \copy views_vec10k (id, views, vec) FROM '/tmp/lantern/vector_datasets/views_vec10k.csv' WITH (FORMAT CSV, HEADER);
+-- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we test below)
+VACUUM ANALYZE;
 SET hnsw.init_k = 10;
 -- Note that the (views < 100) condition is quite rare (out of 10,000 rows)
 SELECT COUNT(*) FROM views_vec10k WHERE views < 100;
@@ -193,7 +195,7 @@ EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Total cost: 4.071250
-DEBUG:  LANTERN - Selectivity: 1.000000
+DEBUG:  LANTERN - Selectivity: 0.005326
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 19.000000
 DEBUG:  LANTERN - ---------------------
@@ -201,6 +203,358 @@ DEBUG:  LANTERN - ---------------------
 ---------------------------------------------------------------
  Limit
    ->  Index Scan using hnsw_partial_views_100 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+-- Test that the index selectivity being calculated for partial indexes is correct
+CREATE INDEX hnsw_partial_views_250 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 250;
+INFO:  done init usearch index
+INFO:  inserted 126 elements
+INFO:  done saving 126 vectors
+CREATE INDEX hnsw_partial_views_500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 500;
+INFO:  done init usearch index
+INFO:  inserted 239 elements
+INFO:  done saving 239 vectors
+CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
+INFO:  done init usearch index
+INFO:  inserted 477 elements
+INFO:  done saving 477 vectors
+CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
+INFO:  done init usearch index
+INFO:  inserted 996 elements
+INFO:  done saving 996 vectors
+CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
+INFO:  done init usearch index
+INFO:  inserted 2021 elements
+INFO:  done saving 2021 vectors
+CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
+INFO:  done init usearch index
+INFO:  inserted 3972 elements
+INFO:  done saving 3972 vectors
+CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
+INFO:  done init usearch index
+INFO:  inserted 8014 elements
+INFO:  done saving 8014 vectors
+CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
+INFO:  done init usearch index
+INFO:  inserted 9485 elements
+INFO:  done saving 9485 vectors
+-- Trigger each partial index by using its exact filter in a filtered query
+-- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
+-- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
+DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
+DEBUG:  LANTERN - Num tuples: 332.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
+DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
+DEBUG:  LANTERN - Num tuples: 159.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 12.592500
+DEBUG:  LANTERN - Selectivity: 0.023941
+DEBUG:  LANTERN - Num pages: 3.000000
+DEBUG:  LANTERN - Num tuples: 79.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 8.315000
+DEBUG:  LANTERN - Selectivity: 0.012738
+DEBUG:  LANTERN - Num pages: 2.000000
+DEBUG:  LANTERN - Num tuples: 42.000000
+DEBUG:  LANTERN - ---------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_250 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
+DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
+DEBUG:  LANTERN - Num tuples: 332.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
+DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
+DEBUG:  LANTERN - Num tuples: 159.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 12.592500
+DEBUG:  LANTERN - Selectivity: 0.023941
+DEBUG:  LANTERN - Num pages: 3.000000
+DEBUG:  LANTERN - Num tuples: 79.000000
+DEBUG:  LANTERN - ---------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_500 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
+DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
+DEBUG:  LANTERN - Num tuples: 332.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
+DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
+DEBUG:  LANTERN - Num tuples: 159.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_1000 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
+DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
+DEBUG:  LANTERN - Num tuples: 332.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_2000 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_4000 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_8000 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_16000 on views_vec10k
+         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
+(3 rows)
+
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_partial_views_19000 on views_vec10k
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -242,6 +242,8 @@ INFO:  done saving 9485 vectors
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
+-- note that every partial index above will output a selectivity in the lantern debug log
+-- so, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -163,9 +163,7 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 DROP INDEX hnsw_idx;
--- Output below could slightly differ on some OS/systems if we log everything
-SET client_min_messages=debug4;
--- Goal: Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
+-- Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
 -- this is relevant in this check in estimate_number_blocks_accessed in hnsw.c:
 -- const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
 -- One place where this happens is on partial indexes where the filter is rare (empirically, matching <2.5% of the entire table)
@@ -177,7 +175,7 @@ CREATE TABLE IF NOT EXISTS views_vec10k (
      vec REAL[]
 );
 \copy views_vec10k (id, views, vec) FROM '/tmp/lantern/vector_datasets/views_vec10k.csv' WITH (FORMAT CSV, HEADER);
--- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we also test below)
+-- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we test below)
 VACUUM ANALYZE;
 SET hnsw.init_k = 10;
 -- Note that the (views < 100) condition is quite rare (out of 10,000 rows)
@@ -192,19 +190,13 @@ CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_op
 INFO:  done init usearch index
 INFO:  inserted 58 elements
 INFO:  done saving 58 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_100', false);
-INFO:  validate_index() start for hnsw_partial_views_100
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 -- This should use the partial index we just created, since it is an exact filter match
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 4.071250
 DEBUG:  LANTERN - Selectivity: 0.005326
+DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 19.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -214,147 +206,99 @@ DEBUG:  LANTERN - ---------------------
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
--- Goal: Test that the index selectivity being calculated for partial indexes is correct
+-- Test that the index selectivity being calculated for partial indexes is correct
 CREATE INDEX hnsw_partial_views_250 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 250;
 INFO:  done init usearch index
 INFO:  inserted 126 elements
 INFO:  done saving 126 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_250', false);
-INFO:  validate_index() start for hnsw_partial_views_250
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 500;
 INFO:  done init usearch index
 INFO:  inserted 239 elements
 INFO:  done saving 239 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_500', false);
-INFO:  validate_index() start for hnsw_partial_views_500
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
 INFO:  done init usearch index
 INFO:  inserted 477 elements
 INFO:  done saving 477 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
-INFO:  validate_index() start for hnsw_partial_views_1000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
 INFO:  done init usearch index
 INFO:  inserted 996 elements
 INFO:  done saving 996 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_2000', false);
-INFO:  validate_index() start for hnsw_partial_views_2000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
 INFO:  done init usearch index
 INFO:  inserted 2021 elements
 INFO:  done saving 2021 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
-INFO:  validate_index() start for hnsw_partial_views_4000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
 INFO:  done init usearch index
 INFO:  inserted 3972 elements
 INFO:  done saving 3972 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
-INFO:  validate_index() start for hnsw_partial_views_8000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
 INFO:  done init usearch index
 INFO:  inserted 8014 elements
 INFO:  done saving 8014 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
-INFO:  validate_index() start for hnsw_partial_views_16000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
 INFO:  done init usearch index
 INFO:  inserted 9485 elements
 INFO:  done saving 9485 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
-INFO:  validate_index() start for hnsw_partial_views_19000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 -- note that every partial index above will output a selectivity in the lantern debug log
--- for example, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
+-- so, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 12.592500
 DEBUG:  LANTERN - Selectivity: 0.023941
+DEBUG:  LANTERN - Num pages: 3.000000
 DEBUG:  LANTERN - Num tuples: 79.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 8.315000
 DEBUG:  LANTERN - Selectivity: 0.012738
+DEBUG:  LANTERN - Num pages: 2.000000
 DEBUG:  LANTERN - Num tuples: 42.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -367,37 +311,51 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 12.592500
 DEBUG:  LANTERN - Selectivity: 0.023941
+DEBUG:  LANTERN - Num pages: 3.000000
 DEBUG:  LANTERN - Num tuples: 79.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -410,32 +368,44 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -448,27 +418,37 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -481,22 +461,30 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -509,17 +497,23 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -532,12 +526,16 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            
@@ -550,7 +548,9 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -207,6 +207,7 @@ DEBUG:  LANTERN - ---------------------
 (3 rows)
 
 -- Goal: Test that the index selectivity being calculated for partial indexes is correct
+-- note that these boundaries are selected so that mac num_pages and cost values align
 CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
 INFO:  done init usearch index
 INFO:  inserted 477 elements
@@ -255,36 +256,12 @@ INFO:  validate_index() done, no issues found.
  
 (1 row)
 
-CREATE INDEX hnsw_partial_views_5000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 5000;
-INFO:  done init usearch index
-INFO:  inserted 2502 elements
-INFO:  done saving 2502 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_5000', false);
-INFO:  validate_index() start for hnsw_partial_views_5000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 CREATE INDEX hnsw_partial_views_6000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 6000;
 INFO:  done init usearch index
 INFO:  inserted 2997 elements
 INFO:  done saving 2997 vectors
 SELECT _lantern_internal.validate_index('hnsw_partial_views_6000', false);
 INFO:  validate_index() start for hnsw_partial_views_6000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_7000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 7000;
-INFO:  done init usearch index
-INFO:  inserted 3458 elements
-INFO:  done saving 3458 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_7000', false);
-INFO:  validate_index() start for hnsw_partial_views_7000
 INFO:  validate_index() done, no issues found.
  validate_index 
 ----------------
@@ -303,239 +280,12 @@ INFO:  validate_index() done, no issues found.
  
 (1 row)
 
-CREATE INDEX hnsw_partial_views_9000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 9000;
-INFO:  done init usearch index
-INFO:  inserted 4444 elements
-INFO:  done saving 4444 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_9000', false);
-INFO:  validate_index() start for hnsw_partial_views_9000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_10000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 10000;
-INFO:  done init usearch index
-INFO:  inserted 4947 elements
-INFO:  done saving 4947 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_10000', false);
-INFO:  validate_index() start for hnsw_partial_views_10000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_11000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 11000;
-INFO:  done init usearch index
-INFO:  inserted 5434 elements
-INFO:  done saving 5434 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_11000', false);
-INFO:  validate_index() start for hnsw_partial_views_11000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_12000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 12000;
-INFO:  done init usearch index
-INFO:  inserted 5949 elements
-INFO:  done saving 5949 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_12000', false);
-INFO:  validate_index() start for hnsw_partial_views_12000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_13000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 13000;
-INFO:  done init usearch index
-INFO:  inserted 6464 elements
-INFO:  done saving 6464 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_13000', false);
-INFO:  validate_index() start for hnsw_partial_views_13000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_14000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 14000;
-INFO:  done init usearch index
-INFO:  inserted 6951 elements
-INFO:  done saving 6951 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_14000', false);
-INFO:  validate_index() start for hnsw_partial_views_14000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_15000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 15000;
-INFO:  done init usearch index
-INFO:  inserted 7489 elements
-INFO:  done saving 7489 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_15000', false);
-INFO:  validate_index() start for hnsw_partial_views_15000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
-INFO:  done init usearch index
-INFO:  inserted 8014 elements
-INFO:  done saving 8014 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
-INFO:  validate_index() start for hnsw_partial_views_16000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_17000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 17000;
-INFO:  done init usearch index
-INFO:  inserted 8540 elements
-INFO:  done saving 8540 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_17000', false);
-INFO:  validate_index() start for hnsw_partial_views_17000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_18000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 18000;
-INFO:  done init usearch index
-INFO:  inserted 9016 elements
-INFO:  done saving 9016 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_18000', false);
-INFO:  validate_index() start for hnsw_partial_views_18000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
-INFO:  done init usearch index
-INFO:  inserted 9485 elements
-INFO:  done saving 9485 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
-INFO:  validate_index() start for hnsw_partial_views_19000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
-CREATE INDEX hnsw_partial_views_20000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 20000;
-INFO:  done init usearch index
-INFO:  inserted 10000 elements
-INFO:  done saving 10000 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_20000', false);
-INFO:  validate_index() start for hnsw_partial_views_20000
-INFO:  validate_index() done, no issues found.
- validate_index 
-----------------
- 
-(1 row)
-
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 -- note that all partial indexes whose filter is a superset of the filter in the query will output indexSelectivity to ldb_dlog below
+-- so, it suffices to call the "smallest" filter, and we will get the selectivity for all the other indices since their filters are nested subsets of each other
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 348.395151
-DEBUG:  LANTERN - Selectivity: 0.999903
-DEBUG:  LANTERN - Num pages: 81.000000
-DEBUG:  LANTERN - Num tuples: 3333.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 313.936500
-DEBUG:  LANTERN - Selectivity: 0.901402
-DEBUG:  LANTERN - Num pages: 73.000000
-DEBUG:  LANTERN - Num tuples: 3005.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 296.743732
-DEBUG:  LANTERN - Selectivity: 0.853878
-DEBUG:  LANTERN - Num pages: 69.000000
-DEBUG:  LANTERN - Num tuples: 2846.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 262.125714
-DEBUG:  LANTERN - Selectivity: 0.747985
-DEBUG:  LANTERN - Num pages: 61.000000
-DEBUG:  LANTERN - Num tuples: 2496.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 244.788432
-DEBUG:  LANTERN - Selectivity: 0.694747
-DEBUG:  LANTERN - Num pages: 57.000000
-DEBUG:  LANTERN - Num tuples: 2317.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 227.567545
-DEBUG:  LANTERN - Selectivity: 0.646264
-DEBUG:  LANTERN - Num pages: 53.000000
-DEBUG:  LANTERN - Num tuples: 2154.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 206.568980
-DEBUG:  LANTERN - Selectivity: 0.594753
-DEBUG:  LANTERN - Num pages: 48.000000
-DEBUG:  LANTERN - Num tuples: 1983.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 189.280667
-DEBUG:  LANTERN - Selectivity: 0.543482
-DEBUG:  LANTERN - Num pages: 44.000000
-DEBUG:  LANTERN - Num tuples: 1811.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 172.065854
-DEBUG:  LANTERN - Selectivity: 0.494979
-DEBUG:  LANTERN - Num pages: 40.000000
-DEBUG:  LANTERN - Num tuples: 1649.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 154.807297
-DEBUG:  LANTERN - Selectivity: 0.444917
-DEBUG:  LANTERN - Num pages: 36.000000
-DEBUG:  LANTERN - Num tuples: 1481.000000
-DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Total cost: 141.637941
@@ -545,24 +295,10 @@ DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 120.342069
-DEBUG:  LANTERN - Selectivity: 0.345671
-DEBUG:  LANTERN - Num pages: 28.000000
-DEBUG:  LANTERN - Num tuples: 1152.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Total cost: 107.204327
 DEBUG:  LANTERN - Selectivity: 0.299812
 DEBUG:  LANTERN - Num pages: 25.000000
 DEBUG:  LANTERN - Num tuples: 999.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 89.970682
-DEBUG:  LANTERN - Selectivity: 0.250364
-DEBUG:  LANTERN - Num pages: 21.000000
-DEBUG:  LANTERN - Num tuples: 834.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
@@ -599,24 +335,3 @@ DEBUG:  LANTERN - ---------------------
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
-/*
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 3000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 5000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 6000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 7000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 9000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 10000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 11000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 12000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 13000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 14000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 15000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 17000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 18000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 20000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-*/

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -163,7 +163,9 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 DROP INDEX hnsw_idx;
--- Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
+-- Output below could slightly differ on some OS/systems if we log everything
+SET client_min_messages=debug4;
+-- Goal: Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
 -- this is relevant in this check in estimate_number_blocks_accessed in hnsw.c:
 -- const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
 -- One place where this happens is on partial indexes where the filter is rare (empirically, matching <2.5% of the entire table)
@@ -175,7 +177,7 @@ CREATE TABLE IF NOT EXISTS views_vec10k (
      vec REAL[]
 );
 \copy views_vec10k (id, views, vec) FROM '/tmp/lantern/vector_datasets/views_vec10k.csv' WITH (FORMAT CSV, HEADER);
--- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we test below)
+-- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we also test below)
 VACUUM ANALYZE;
 SET hnsw.init_k = 10;
 -- Note that the (views < 100) condition is quite rare (out of 10,000 rows)
@@ -190,13 +192,19 @@ CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_op
 INFO:  done init usearch index
 INFO:  inserted 58 elements
 INFO:  done saving 58 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_100', false);
+INFO:  validate_index() start for hnsw_partial_views_100
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 -- This should use the partial index we just created, since it is an exact filter match
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 4.071250
 DEBUG:  LANTERN - Selectivity: 0.005326
-DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 19.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -206,99 +214,147 @@ DEBUG:  LANTERN - ---------------------
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
--- Test that the index selectivity being calculated for partial indexes is correct
+-- Goal: Test that the index selectivity being calculated for partial indexes is correct
 CREATE INDEX hnsw_partial_views_250 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 250;
 INFO:  done init usearch index
 INFO:  inserted 126 elements
 INFO:  done saving 126 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_250', false);
+INFO:  validate_index() start for hnsw_partial_views_250
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 500;
 INFO:  done init usearch index
 INFO:  inserted 239 elements
 INFO:  done saving 239 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_500', false);
+INFO:  validate_index() start for hnsw_partial_views_500
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
 INFO:  done init usearch index
 INFO:  inserted 477 elements
 INFO:  done saving 477 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
+INFO:  validate_index() start for hnsw_partial_views_1000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
 INFO:  done init usearch index
 INFO:  inserted 996 elements
 INFO:  done saving 996 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_2000', false);
+INFO:  validate_index() start for hnsw_partial_views_2000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
 INFO:  done init usearch index
 INFO:  inserted 2021 elements
 INFO:  done saving 2021 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
+INFO:  validate_index() start for hnsw_partial_views_4000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
 INFO:  done init usearch index
 INFO:  inserted 3972 elements
 INFO:  done saving 3972 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
+INFO:  validate_index() start for hnsw_partial_views_8000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
 INFO:  done init usearch index
 INFO:  inserted 8014 elements
 INFO:  done saving 8014 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
+INFO:  validate_index() start for hnsw_partial_views_16000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
 INFO:  done init usearch index
 INFO:  inserted 9485 elements
 INFO:  done saving 9485 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
+INFO:  validate_index() start for hnsw_partial_views_19000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 -- note that every partial index above will output a selectivity in the lantern debug log
--- so, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
+-- for example, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 12.592500
 DEBUG:  LANTERN - Selectivity: 0.023941
-DEBUG:  LANTERN - Num pages: 3.000000
 DEBUG:  LANTERN - Num tuples: 79.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 8.315000
 DEBUG:  LANTERN - Selectivity: 0.012738
-DEBUG:  LANTERN - Num pages: 2.000000
 DEBUG:  LANTERN - Num tuples: 42.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -311,51 +367,37 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 12.592500
 DEBUG:  LANTERN - Selectivity: 0.023941
-DEBUG:  LANTERN - Num pages: 3.000000
 DEBUG:  LANTERN - Num tuples: 79.000000
 DEBUG:  LANTERN - ---------------------
                           QUERY PLAN                           
@@ -368,44 +410,32 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
 DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
 DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -418,37 +448,27 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
 DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
 DEBUG:  LANTERN - Num tuples: 332.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -461,30 +481,22 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
 DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
 DEBUG:  LANTERN - Num tuples: 673.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -497,23 +509,17 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
 DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
 DEBUG:  LANTERN - Num tuples: 1324.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
@@ -526,16 +532,12 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
 DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
 DEBUG:  LANTERN - Num tuples: 2671.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            
@@ -548,9 +550,7 @@ DEBUG:  LANTERN - ---------------------
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
 DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
 DEBUG:  LANTERN - Num tuples: 3161.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -163,7 +163,7 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 DROP INDEX hnsw_idx;
--- Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
+-- Goal: Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
 -- this is relevant in this check in estimate_number_blocks_accessed in hnsw.c:
 -- const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
 -- One place where this happens is on partial indexes where the filter is rare (empirically, matching <2.5% of the entire table)
@@ -206,357 +206,110 @@ DEBUG:  LANTERN - ---------------------
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
--- Test that the index selectivity being calculated for partial indexes is correct
-CREATE INDEX hnsw_partial_views_250 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 250;
+-- Goal: Test that the index selectivity being calculated for partial indexes is correct
+CREATE INDEX hnsw_partial_views_1500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1500;
 INFO:  done init usearch index
-INFO:  inserted 126 elements
-INFO:  done saving 126 vectors
-CREATE INDEX hnsw_partial_views_500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 500;
+INFO:  inserted 749 elements
+INFO:  done saving 749 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_1500', false);
+INFO:  validate_index() start for hnsw_partial_views_1500
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_10000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 10000;
 INFO:  done init usearch index
-INFO:  inserted 239 elements
-INFO:  done saving 239 vectors
-CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
+INFO:  inserted 4947 elements
+INFO:  done saving 4947 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_10000', false);
+INFO:  validate_index() start for hnsw_partial_views_10000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_17000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 17000;
 INFO:  done init usearch index
-INFO:  inserted 477 elements
-INFO:  done saving 477 vectors
-CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
-INFO:  done init usearch index
-INFO:  inserted 996 elements
-INFO:  done saving 996 vectors
-CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
-INFO:  done init usearch index
-INFO:  inserted 2021 elements
-INFO:  done saving 2021 vectors
-CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
-INFO:  done init usearch index
-INFO:  inserted 3972 elements
-INFO:  done saving 3972 vectors
-CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
-INFO:  done init usearch index
-INFO:  inserted 8014 elements
-INFO:  done saving 8014 vectors
-CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
-INFO:  done init usearch index
-INFO:  inserted 9485 elements
-INFO:  done saving 9485 vectors
+INFO:  inserted 8540 elements
+INFO:  done saving 8540 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_17000', false);
+INFO:  validate_index() start for hnsw_partial_views_17000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
--- note that every partial index above will output a selectivity in the lantern debug log
--- so, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+-- note that all partial indexes whose filter is a superset of the filter in the query will output indexSelectivity to ldb_dlog below
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - Total cost: 296.743732
+DEBUG:  LANTERN - Selectivity: 0.853878
+DEBUG:  LANTERN - Num pages: 69.000000
+DEBUG:  LANTERN - Num tuples: 2846.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - Total cost: 172.065854
+DEBUG:  LANTERN - Selectivity: 0.494979
+DEBUG:  LANTERN - Num pages: 40.000000
+DEBUG:  LANTERN - Num tuples: 1649.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
-DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
-DEBUG:  LANTERN - Num tuples: 673.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
-DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
-DEBUG:  LANTERN - Num tuples: 332.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
-DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
-DEBUG:  LANTERN - Num tuples: 159.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 12.592500
-DEBUG:  LANTERN - Selectivity: 0.023941
-DEBUG:  LANTERN - Num pages: 3.000000
-DEBUG:  LANTERN - Num tuples: 79.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 8.315000
-DEBUG:  LANTERN - Selectivity: 0.012738
-DEBUG:  LANTERN - Num pages: 2.000000
-DEBUG:  LANTERN - Num tuples: 42.000000
-DEBUG:  LANTERN - ---------------------
-                          QUERY PLAN                           
----------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_250 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
-DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
-DEBUG:  LANTERN - Num tuples: 673.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
-DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
-DEBUG:  LANTERN - Num tuples: 332.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
-DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
-DEBUG:  LANTERN - Num tuples: 159.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 12.592500
-DEBUG:  LANTERN - Selectivity: 0.023941
-DEBUG:  LANTERN - Num pages: 3.000000
-DEBUG:  LANTERN - Num tuples: 79.000000
-DEBUG:  LANTERN - ---------------------
-                          QUERY PLAN                           
----------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_500 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
-DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
-DEBUG:  LANTERN - Num tuples: 673.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
-DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
-DEBUG:  LANTERN - Num tuples: 332.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 21.192500
-DEBUG:  LANTERN - Selectivity: 0.047342
-DEBUG:  LANTERN - Num pages: 5.000000
-DEBUG:  LANTERN - Num tuples: 159.000000
+DEBUG:  LANTERN - Total cost: 29.867500
+DEBUG:  LANTERN - Selectivity: 0.075139
+DEBUG:  LANTERN - Num pages: 7.000000
+DEBUG:  LANTERN - Num tuples: 249.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_partial_views_1000 on views_vec10k
+   ->  Index Scan using hnsw_partial_views_1500 on views_vec10k
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 10000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - Total cost: 296.743732
+DEBUG:  LANTERN - Selectivity: 0.853878
+DEBUG:  LANTERN - Num pages: 69.000000
+DEBUG:  LANTERN - Num tuples: 2846.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
-DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
-DEBUG:  LANTERN - Num tuples: 673.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 38.490000
-DEBUG:  LANTERN - Selectivity: 0.099913
-DEBUG:  LANTERN - Num pages: 9.000000
-DEBUG:  LANTERN - Num tuples: 332.000000
-DEBUG:  LANTERN - ---------------------
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_2000 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 72.767083
-DEBUG:  LANTERN - Selectivity: 0.201732
-DEBUG:  LANTERN - Num pages: 17.000000
-DEBUG:  LANTERN - Num tuples: 673.000000
-DEBUG:  LANTERN - ---------------------
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_4000 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 141.637941
-DEBUG:  LANTERN - Selectivity: 0.397306
-DEBUG:  LANTERN - Num pages: 33.000000
-DEBUG:  LANTERN - Num tuples: 1324.000000
-DEBUG:  LANTERN - ---------------------
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_8000 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 279.434515
-DEBUG:  LANTERN - Selectivity: 0.801667
-DEBUG:  LANTERN - Num pages: 65.000000
-DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - Total cost: 172.065854
+DEBUG:  LANTERN - Selectivity: 0.494979
+DEBUG:  LANTERN - Num pages: 40.000000
+DEBUG:  LANTERN - Num tuples: 1649.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_partial_views_16000 on views_vec10k
+   ->  Index Scan using hnsw_partial_views_10000 on views_vec10k
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 17000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 331.107310
-DEBUG:  LANTERN - Selectivity: 0.948491
-DEBUG:  LANTERN - Num pages: 77.000000
-DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - Total cost: 296.743732
+DEBUG:  LANTERN - Selectivity: 0.853878
+DEBUG:  LANTERN - Num pages: 69.000000
+DEBUG:  LANTERN - Num tuples: 2846.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_partial_views_19000 on views_vec10k
+   ->  Index Scan using hnsw_partial_views_17000 on views_vec10k
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -207,12 +207,108 @@ DEBUG:  LANTERN - ---------------------
 (3 rows)
 
 -- Goal: Test that the index selectivity being calculated for partial indexes is correct
-CREATE INDEX hnsw_partial_views_1500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1500;
+CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
 INFO:  done init usearch index
-INFO:  inserted 749 elements
-INFO:  done saving 749 vectors
-SELECT _lantern_internal.validate_index('hnsw_partial_views_1500', false);
-INFO:  validate_index() start for hnsw_partial_views_1500
+INFO:  inserted 477 elements
+INFO:  done saving 477 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
+INFO:  validate_index() start for hnsw_partial_views_1000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
+INFO:  done init usearch index
+INFO:  inserted 996 elements
+INFO:  done saving 996 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_2000', false);
+INFO:  validate_index() start for hnsw_partial_views_2000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_3000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 3000;
+INFO:  done init usearch index
+INFO:  inserted 1490 elements
+INFO:  done saving 1490 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_3000', false);
+INFO:  validate_index() start for hnsw_partial_views_3000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
+INFO:  done init usearch index
+INFO:  inserted 2021 elements
+INFO:  done saving 2021 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
+INFO:  validate_index() start for hnsw_partial_views_4000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_5000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 5000;
+INFO:  done init usearch index
+INFO:  inserted 2502 elements
+INFO:  done saving 2502 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_5000', false);
+INFO:  validate_index() start for hnsw_partial_views_5000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_6000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 6000;
+INFO:  done init usearch index
+INFO:  inserted 2997 elements
+INFO:  done saving 2997 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_6000', false);
+INFO:  validate_index() start for hnsw_partial_views_6000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_7000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 7000;
+INFO:  done init usearch index
+INFO:  inserted 3458 elements
+INFO:  done saving 3458 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_7000', false);
+INFO:  validate_index() start for hnsw_partial_views_7000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
+INFO:  done init usearch index
+INFO:  inserted 3972 elements
+INFO:  done saving 3972 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
+INFO:  validate_index() start for hnsw_partial_views_8000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_9000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 9000;
+INFO:  done init usearch index
+INFO:  inserted 4444 elements
+INFO:  done saving 4444 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_9000', false);
+INFO:  validate_index() start for hnsw_partial_views_9000
 INFO:  validate_index() done, no issues found.
  validate_index 
 ----------------
@@ -231,6 +327,78 @@ INFO:  validate_index() done, no issues found.
  
 (1 row)
 
+CREATE INDEX hnsw_partial_views_11000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 11000;
+INFO:  done init usearch index
+INFO:  inserted 5434 elements
+INFO:  done saving 5434 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_11000', false);
+INFO:  validate_index() start for hnsw_partial_views_11000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_12000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 12000;
+INFO:  done init usearch index
+INFO:  inserted 5949 elements
+INFO:  done saving 5949 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_12000', false);
+INFO:  validate_index() start for hnsw_partial_views_12000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_13000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 13000;
+INFO:  done init usearch index
+INFO:  inserted 6464 elements
+INFO:  done saving 6464 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_13000', false);
+INFO:  validate_index() start for hnsw_partial_views_13000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_14000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 14000;
+INFO:  done init usearch index
+INFO:  inserted 6951 elements
+INFO:  done saving 6951 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_14000', false);
+INFO:  validate_index() start for hnsw_partial_views_14000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_15000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 15000;
+INFO:  done init usearch index
+INFO:  inserted 7489 elements
+INFO:  done saving 7489 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_15000', false);
+INFO:  validate_index() start for hnsw_partial_views_15000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
+INFO:  done init usearch index
+INFO:  inserted 8014 elements
+INFO:  done saving 8014 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
+INFO:  validate_index() start for hnsw_partial_views_16000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 CREATE INDEX hnsw_partial_views_17000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 17000;
 INFO:  done init usearch index
 INFO:  inserted 8540 elements
@@ -243,17 +411,116 @@ INFO:  validate_index() done, no issues found.
  
 (1 row)
 
+CREATE INDEX hnsw_partial_views_18000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 18000;
+INFO:  done init usearch index
+INFO:  inserted 9016 elements
+INFO:  done saving 9016 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_18000', false);
+INFO:  validate_index() start for hnsw_partial_views_18000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
+INFO:  done init usearch index
+INFO:  inserted 9485 elements
+INFO:  done saving 9485 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
+INFO:  validate_index() start for hnsw_partial_views_19000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_partial_views_20000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 20000;
+INFO:  done init usearch index
+INFO:  inserted 10000 elements
+INFO:  done saving 10000 vectors
+SELECT _lantern_internal.validate_index('hnsw_partial_views_20000', false);
+INFO:  validate_index() start for hnsw_partial_views_20000
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 -- note that all partial indexes whose filter is a superset of the filter in the query will output indexSelectivity to ldb_dlog below
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 348.395151
+DEBUG:  LANTERN - Selectivity: 0.999903
+DEBUG:  LANTERN - Num pages: 81.000000
+DEBUG:  LANTERN - Num tuples: 3333.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 331.107310
+DEBUG:  LANTERN - Selectivity: 0.948491
+DEBUG:  LANTERN - Num pages: 77.000000
+DEBUG:  LANTERN - Num tuples: 3161.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 313.936500
+DEBUG:  LANTERN - Selectivity: 0.901402
+DEBUG:  LANTERN - Num pages: 73.000000
+DEBUG:  LANTERN - Num tuples: 3005.000000
+DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Total cost: 296.743732
 DEBUG:  LANTERN - Selectivity: 0.853878
 DEBUG:  LANTERN - Num pages: 69.000000
 DEBUG:  LANTERN - Num tuples: 2846.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 279.434515
+DEBUG:  LANTERN - Selectivity: 0.801667
+DEBUG:  LANTERN - Num pages: 65.000000
+DEBUG:  LANTERN - Num tuples: 2671.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 262.125714
+DEBUG:  LANTERN - Selectivity: 0.747985
+DEBUG:  LANTERN - Num pages: 61.000000
+DEBUG:  LANTERN - Num tuples: 2496.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 244.788432
+DEBUG:  LANTERN - Selectivity: 0.694747
+DEBUG:  LANTERN - Num pages: 57.000000
+DEBUG:  LANTERN - Num tuples: 2317.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 227.567545
+DEBUG:  LANTERN - Selectivity: 0.646264
+DEBUG:  LANTERN - Num pages: 53.000000
+DEBUG:  LANTERN - Num tuples: 2154.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 206.568980
+DEBUG:  LANTERN - Selectivity: 0.594753
+DEBUG:  LANTERN - Num pages: 48.000000
+DEBUG:  LANTERN - Num tuples: 1983.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 189.280667
+DEBUG:  LANTERN - Selectivity: 0.543482
+DEBUG:  LANTERN - Num pages: 44.000000
+DEBUG:  LANTERN - Num tuples: 1811.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
@@ -264,52 +531,92 @@ DEBUG:  LANTERN - Num tuples: 1649.000000
 DEBUG:  LANTERN - ---------------------
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 29.867500
-DEBUG:  LANTERN - Selectivity: 0.075139
-DEBUG:  LANTERN - Num pages: 7.000000
-DEBUG:  LANTERN - Num tuples: 249.000000
+DEBUG:  LANTERN - Total cost: 154.807297
+DEBUG:  LANTERN - Selectivity: 0.444917
+DEBUG:  LANTERN - Num pages: 36.000000
+DEBUG:  LANTERN - Num tuples: 1481.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 141.637941
+DEBUG:  LANTERN - Selectivity: 0.397306
+DEBUG:  LANTERN - Num pages: 33.000000
+DEBUG:  LANTERN - Num tuples: 1324.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 120.342069
+DEBUG:  LANTERN - Selectivity: 0.345671
+DEBUG:  LANTERN - Num pages: 28.000000
+DEBUG:  LANTERN - Num tuples: 1152.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 107.204327
+DEBUG:  LANTERN - Selectivity: 0.299812
+DEBUG:  LANTERN - Num pages: 25.000000
+DEBUG:  LANTERN - Num tuples: 999.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 89.970682
+DEBUG:  LANTERN - Selectivity: 0.250364
+DEBUG:  LANTERN - Num pages: 21.000000
+DEBUG:  LANTERN - Num tuples: 834.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 72.767083
+DEBUG:  LANTERN - Selectivity: 0.201732
+DEBUG:  LANTERN - Num pages: 17.000000
+DEBUG:  LANTERN - Num tuples: 673.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 55.720000
+DEBUG:  LANTERN - Selectivity: 0.148849
+DEBUG:  LANTERN - Num pages: 13.000000
+DEBUG:  LANTERN - Num tuples: 496.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 38.490000
+DEBUG:  LANTERN - Selectivity: 0.099913
+DEBUG:  LANTERN - Num pages: 9.000000
+DEBUG:  LANTERN - Num tuples: 332.000000
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Query cost estimator
+DEBUG:  LANTERN - ---------------------
+DEBUG:  LANTERN - Total cost: 21.192500
+DEBUG:  LANTERN - Selectivity: 0.047342
+DEBUG:  LANTERN - Num pages: 5.000000
+DEBUG:  LANTERN - Num tuples: 159.000000
 DEBUG:  LANTERN - ---------------------
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_partial_views_1500 on views_vec10k
+   ->  Index Scan using hnsw_partial_views_1000 on views_vec10k
          Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
 (3 rows)
 
+/*
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 3000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 5000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 6000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 7000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 9000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 10000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 296.743732
-DEBUG:  LANTERN - Selectivity: 0.853878
-DEBUG:  LANTERN - Num pages: 69.000000
-DEBUG:  LANTERN - Num tuples: 2846.000000
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 172.065854
-DEBUG:  LANTERN - Selectivity: 0.494979
-DEBUG:  LANTERN - Num pages: 40.000000
-DEBUG:  LANTERN - Num tuples: 1649.000000
-DEBUG:  LANTERN - ---------------------
-                           QUERY PLAN                            
------------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_10000 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 11000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 12000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 13000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 14000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 15000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 17000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-DEBUG:  LANTERN - Query cost estimator
-DEBUG:  LANTERN - ---------------------
-DEBUG:  LANTERN - Total cost: 296.743732
-DEBUG:  LANTERN - Selectivity: 0.853878
-DEBUG:  LANTERN - Num pages: 69.000000
-DEBUG:  LANTERN - Num tuples: 2846.000000
-DEBUG:  LANTERN - ---------------------
-                           QUERY PLAN                            
------------------------------------------------------------------
- Limit
-   ->  Index Scan using hnsw_partial_views_17000 on views_vec10k
-         Order By: (vec <-> '{0,1,2,3,4,5}'::real[])
-(3 rows)
-
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 18000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 20000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+*/

--- a/test/sql/hnsw_cost_estimate.sql
+++ b/test/sql/hnsw_cost_estimate.sql
@@ -105,21 +105,93 @@ CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_op
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 
 -- Goal: Test that the index selectivity being calculated for partial indexes is correct
-CREATE INDEX hnsw_partial_views_1500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1500;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_1500', false);
+CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
+
+CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_2000', false);
+
+CREATE INDEX hnsw_partial_views_3000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 3000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_3000', false);
+
+CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
+
+CREATE INDEX hnsw_partial_views_5000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 5000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_5000', false);
+
+CREATE INDEX hnsw_partial_views_6000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 6000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_6000', false);
+
+CREATE INDEX hnsw_partial_views_7000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 7000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_7000', false);
+
+CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
+
+CREATE INDEX hnsw_partial_views_9000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 9000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_9000', false);
 
 CREATE INDEX hnsw_partial_views_10000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 10000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_10000', false);
 
+CREATE INDEX hnsw_partial_views_11000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 11000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_11000', false);
+
+CREATE INDEX hnsw_partial_views_12000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 12000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_12000', false);
+
+CREATE INDEX hnsw_partial_views_13000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 13000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_13000', false);
+
+CREATE INDEX hnsw_partial_views_14000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 14000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_14000', false);
+
+CREATE INDEX hnsw_partial_views_15000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 15000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_15000', false);
+
+CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
+
 CREATE INDEX hnsw_partial_views_17000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 17000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_17000', false);
+
+CREATE INDEX hnsw_partial_views_18000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 18000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_18000', false);
+
+CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
+
+CREATE INDEX hnsw_partial_views_20000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 20000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_20000', false);
 
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 
 -- note that all partial indexes whose filter is a superset of the filter in the query will output indexSelectivity to ldb_dlog below
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+/*
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 3000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 5000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 6000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 7000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 9000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 10000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 11000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 12000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 13000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 14000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 15000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 17000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 18000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 20000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
+*/
+
+
 

--- a/test/sql/hnsw_cost_estimate.sql
+++ b/test/sql/hnsw_cost_estimate.sql
@@ -82,7 +82,10 @@ SELECT _lantern_internal.validate_index('hnsw_idx', false);
 DROP INDEX hnsw_idx;
 
 
--- Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
+-- Output below could slightly differ on some OS/systems if we log everything
+SET client_min_messages=debug4;
+
+-- Goal: Test cost estimation when number of pages in index is likely less than number of blockmaps allocated
 -- this is relevant in this check in estimate_number_blocks_accessed in hnsw.c:
 -- const uint64 num_datablocks = Max(num_pages - 1 - num_blockmap_allocated, 1);
 
@@ -90,7 +93,7 @@ DROP INDEX hnsw_idx;
 -- This is what we test below
 \ir utils/views_vec10k.sql
 
--- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we test below)
+-- This is important to make sure that index selectivity calculations from genericcostestimate are accurate (which we also test below)
 VACUUM ANALYZE;
 
 SET hnsw.init_k = 10;
@@ -100,26 +103,42 @@ SELECT COUNT(*) FROM views_vec10k WHERE views < 100;
 
 -- Create partial lantern index with (views < 100) filter
 CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 100;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_100', false);
 
 -- This should use the partial index we just created, since it is an exact filter match
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 
--- Test that the index selectivity being calculated for partial indexes is correct
+-- Goal: Test that the index selectivity being calculated for partial indexes is correct
 CREATE INDEX hnsw_partial_views_250 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 250;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_250', false);
+
 CREATE INDEX hnsw_partial_views_500 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 500;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_500', false);
+
 CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
+
 CREATE INDEX hnsw_partial_views_2000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 2000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_2000', false);
+
 CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
+
 CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
+
 CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
+
 CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
+SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
 
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 
 -- note that every partial index above will output a selectivity in the lantern debug log
--- so, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
+-- for example, the views < 250 query will estimate and display costs/selectivity for the 19000, 16000, ..., 500, 250 partial indexes
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 250 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 500 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;

--- a/test/sql/hnsw_cost_estimate.sql
+++ b/test/sql/hnsw_cost_estimate.sql
@@ -105,6 +105,7 @@ CREATE INDEX hnsw_partial_views_100 ON views_vec10k USING hnsw (vec dist_l2sq_op
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 100 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
 
 -- Goal: Test that the index selectivity being calculated for partial indexes is correct
+-- note that these boundaries are selected so that mac num_pages and cost values align
 CREATE INDEX hnsw_partial_views_1000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 1000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_1000', false);
 
@@ -117,81 +118,16 @@ SELECT _lantern_internal.validate_index('hnsw_partial_views_3000', false);
 CREATE INDEX hnsw_partial_views_4000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 4000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_4000', false);
 
-CREATE INDEX hnsw_partial_views_5000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 5000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_5000', false);
-
 CREATE INDEX hnsw_partial_views_6000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 6000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_6000', false);
 
-CREATE INDEX hnsw_partial_views_7000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 7000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_7000', false);
-
 CREATE INDEX hnsw_partial_views_8000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 8000;
 SELECT _lantern_internal.validate_index('hnsw_partial_views_8000', false);
-
-CREATE INDEX hnsw_partial_views_9000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 9000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_9000', false);
-
-CREATE INDEX hnsw_partial_views_10000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 10000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_10000', false);
-
-CREATE INDEX hnsw_partial_views_11000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 11000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_11000', false);
-
-CREATE INDEX hnsw_partial_views_12000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 12000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_12000', false);
-
-CREATE INDEX hnsw_partial_views_13000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 13000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_13000', false);
-
-CREATE INDEX hnsw_partial_views_14000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 14000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_14000', false);
-
-CREATE INDEX hnsw_partial_views_15000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 15000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_15000', false);
-
-CREATE INDEX hnsw_partial_views_16000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 16000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_16000', false);
-
-CREATE INDEX hnsw_partial_views_17000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 17000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_17000', false);
-
-CREATE INDEX hnsw_partial_views_18000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 18000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_18000', false);
-
-CREATE INDEX hnsw_partial_views_19000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 19000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_19000', false);
-
-CREATE INDEX hnsw_partial_views_20000 ON views_vec10k USING hnsw (vec dist_l2sq_ops) WITH (dim=6) WHERE views < 20000;
-SELECT _lantern_internal.validate_index('hnsw_partial_views_20000', false);
 
 -- Trigger each partial index by using its exact filter in a filtered query
 -- Each indexSelectivity value for a partial index with the filter (views < N) should be around N/20000
 -- (in other words, the fraction of rows from the table that is in the partial index, since views ~ Unif[0, 20,000])
 
 -- note that all partial indexes whose filter is a superset of the filter in the query will output indexSelectivity to ldb_dlog below
+-- so, it suffices to call the "smallest" filter, and we will get the selectivity for all the other indices since their filters are nested subsets of each other
 EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 1000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-/*
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 2000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 3000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 4000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 5000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 6000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 7000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 8000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 9000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 10000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 11000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 12000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 13000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 14000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 15000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 16000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 17000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 18000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 19000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-EXPLAIN (COSTS FALSE) SELECT id, views FROM views_vec10k WHERE views < 20000 ORDER BY vec<->'{0,1,2,3,4,5}' LIMIT 10;
-*/
-
-
-


### PR DESCRIPTION
As per [postgres documentation](https://www.postgresql.org/docs/current/index-cost-estimation.html), `indexSelectivity` is the estimated fraction of parent table rows that will be retrieved during the index scan. This was previously hardcoded to `1`, but it should instead be the fraction of parent table rows that are in our index (which can be less than `1` when we have partial indexes).
The `genericcostestimate` function that we call appears to compute this value for us, and so we can use that instead.

I also added tests in `hnsw_cost_estimate` that compute the `indexSelectivity` values (shown in the lantern debug logs that are outputted during this test) for partial indexes, to make sure that `indexSelectivity` is computed properly.