### PR TITLE
PQ Api improvements #288

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -35,7 +35,6 @@ PGDLLEXPORT Datum cos_dist(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum cos_dist_with_guard(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum vector_cos_dist(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum lantern_reindex_external_index(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum create_pq_codebook(PG_FUNCTION_ARGS);
 
 HnswColumnType GetColumnTypeFromOid(Oid oid);
 HnswColumnType GetIndexColumnType(Relation index);

--- a/test/expected/ext_relocation.out
+++ b/test/expected/ext_relocation.out
@@ -44,7 +44,8 @@ ORDER BY 1, 3, 2;
  schema1   | validate_index                         | _lantern_internal
  schema1   | cos_dist                               | schema1
  schema1   | create_pq_codebook                     | schema1
- schema1   | decompress_vector                      | schema1
+ schema1   | dequantize_vector                      | schema1
+ schema1   | drop_quantization                      | schema1
  schema1   | hamming_dist                           | schema1
  schema1   | hnsw_handler                           | schema1
  schema1   | l2sq_dist                              | schema1
@@ -59,7 +60,7 @@ ORDER BY 1, 3, 2;
  schema1   | ldb_pqvec_send                         | schema1
  schema1   | quantize_table                         | schema1
  schema1   | quantize_vector                        | schema1
-(25 rows)
+(26 rows)
 
 -- show all the extension operators
 SELECT ne.nspname AS extschema, op.oprname, np.nspname AS proschema

--- a/test/expected/hnsw_pq.out
+++ b/test/expected/hnsw_pq.out
@@ -96,21 +96,23 @@ SELECT '{84,1,4,128,255}'::INT[]::pqvec;
 SELECT '{84,1,4,128,256}'::pqvec;
 ERROR:  Compressed vector element can not be bigger than 255 at character 8
 -- Verify wrong argument assertions
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'nonexistant', 10, 32, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'nonexistant', 10, 32, 'l2sq', 0);
 ERROR:  Column nonexistant not found in table
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1001, 32, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1001, 32, 'l2sq', 0);
 ERROR:  Cluster count can not be greater than 256
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 33, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 33, 'l2sq', 0);
 ERROR:  Dataset dimensions should be divisible by subvector count
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sqz');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sqz', 0);
 ERROR:  Unsupported metric kind: l2sqz . Should be one of (l2sq, cos, hamming)
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 32, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 32, 'l2sq', 0);
 ERROR:  Cluster count can not be greater than 256
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 0, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 0, 'l2sq', 0);
+ERROR:  Subvector count can not be zero
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 256, 0, 'l2sq', 10);
 ERROR:  Subvector count can not be zero
 \set ON_ERROR_STOP on
 -- This should create codebook[1][1][128]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1, 1, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1, 1, 'l2sq', 0) as codebook \gset
 INFO:  Table scanned. Dataset size 1000
 INFO:  Starting k-means over dataset with (subvectors=1, clusters=1)
 INFO:  Codebooks created
@@ -133,7 +135,7 @@ SELECT array_length(:'codebook'::REAL[][][], 3);
 (1 row)
 
 -- This should create codebook[1][10][128]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 1, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 1, 'l2sq', 0) as codebook \gset
 INFO:  Table scanned. Dataset size 1000
 INFO:  Starting k-means over dataset with (subvectors=1, clusters=10)
 INFO:  Codebooks created
@@ -156,7 +158,7 @@ SELECT array_length(:'codebook'::REAL[][][], 3);
 (1 row)
 
 -- This should create codebook[32][10][4]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sq', 0) as codebook \gset
 INFO:  Table scanned. Dataset size 1000
 INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
 INFO:  Codebooks created
@@ -223,9 +225,9 @@ ERROR:  Cannot modify readonly table.
 INSERT INTO _lantern_internal._codebook_sift_base1k_v (subvector_id, centroid_id, c) VALUES (1, 1, '{1,2,3,4}');
 ERROR:  Cannot modify readonly table.
 -- Validate that compressing invalid vector raises an error
-SELECT decompress_vector('{}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
+SELECT dequantize_vector('{}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
 ERROR:  pqvector can not be empty at character 26
-SELECT decompress_vector('{1,2,3}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
+SELECT dequantize_vector('{1,2,3}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
 ERROR:  Codebook has 32 subvectors, but vector is quantized in 3 subvectors
 \set ON_ERROR_STOP on
 -- Compression and Decompression
@@ -233,8 +235,8 @@ ERROR:  Codebook has 32 subvectors, but vector is quantized in 3 subvectors
 SELECT v as v1 FROM sift_base1k WHERE id=1 \gset
 SELECT v_pq as v1_pq FROM sift_base1k WHERE id=1 \gset
 SELECT quantize_vector(:'v1', '_lantern_internal._codebook_sift_base1k_v'::regclass, 'l2sq') as compressed \gset
-SELECT decompress_vector(:'v1_pq', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_1 \gset
-SELECT decompress_vector(:'compressed', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_2 \gset
+SELECT dequantize_vector(:'v1_pq', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_1 \gset
+SELECT dequantize_vector(:'compressed', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_2 \gset
 SELECT l2sq_dist(:'decompressed_1', :'decompressed_2');
  l2sq_dist 
 -----------
@@ -243,7 +245,7 @@ SELECT l2sq_dist(:'decompressed_1', :'decompressed_2');
 
 -- Test recall for quantized vs non quantized vectors
 ALTER TABLE sift_base1k ADD COLUMN v_pq_dec REAL[];
-UPDATE sift_base1k SET v_pq_dec=decompress_vector(v_pq, '_lantern_internal._codebook_sift_base1k_v');
+UPDATE sift_base1k SET v_pq_dec=dequantize_vector(v_pq, '_lantern_internal._codebook_sift_base1k_v');
 -- Calculate recall over original vector
 SELECT (calculate_table_recall('sift_base1k', 'sift_query1k', 'sift_truth1k', 'v', 10, 100) -
        calculate_table_recall('sift_base1k', 'sift_query1k', 'sift_truth1k', 'v_pq_dec', 10, 100)) as recall_diff \gset
@@ -315,5 +317,98 @@ SELECT array_length(c, 1) FROM _lantern_internal._codebook_sift_base1k_v_pq_dec 
  array_length 
 --------------
             4
+(1 row)
+
+-- Test that resources are being cleared correctly
+SELECT drop_quantization('sift_base1k'::regclass, 'v');
+ drop_quantization 
+-------------------
+ 
+(1 row)
+
+SELECT drop_quantization('sift_base1k'::regclass, 'v_pq_dec');
+ drop_quantization 
+-------------------
+ 
+(1 row)
+
+SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'sift_base1k';
+ column_name 
+-------------
+ id
+ v
+ v_pq_dec
+(3 rows)
+
+SELECT table_name FROM information_schema.tables WHERE table_schema = '_lantern_internal';
+ table_name 
+------------
+(0 rows)
+
+-- Test quantization over subset of data
+SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'l2sq', 500);
+INFO:  Table scanned. Dataset size 500
+INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
+INFO:  Codebooks created
+INFO:  Compressing vectors...
+ quantize_table 
+----------------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT subvector_id) FROM _lantern_internal._codebook_sift_base1k_v;
+ count 
+-------
+    32
+(1 row)
+
+SELECT COUNT(DISTINCT centroid_id) FROM _lantern_internal._codebook_sift_base1k_v;
+ count 
+-------
+    10
+(1 row)
+
+SELECT COUNT(*) FROM _lantern_internal._codebook_sift_base1k_v;
+ count 
+-------
+   320
+(1 row)
+
+SELECT array_length(c, 1) FROM _lantern_internal._codebook_sift_base1k_v LIMIT 1;
+ array_length 
+--------------
+            4
+(1 row)
+
+-- Test quantization with mixed case and schema qualified table name
+SELECT id, v AS "v_New" into "sift_Base1k_NEW" FROM sift_base1k;
+SELECT quantize_table('"public"."sift_Base1k_NEW"'::regclass, 'v_New', 10, 32, 'l2sq');
+INFO:  Table scanned. Dataset size 1001
+INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
+INFO:  Codebooks created
+INFO:  Compressing vectors...
+ quantize_table 
+----------------
+ 
+(1 row)
+
+SELECT array_length(
+              dequantize_vector(
+                     quantize_vector(
+                       (SELECT "v_New" FROM "sift_Base1k_NEW" WHERE id=1), 
+                       '_lantern_internal."_codebook_sift_Base1k_NEW_v_New"'::regclass, 
+                       'l2sq'),  
+              '_lantern_internal."_codebook_sift_Base1k_NEW_v_New"'::regclass),
+              1
+       );
+ array_length 
+--------------
+          128
+(1 row)
+
+SELECT drop_quantization('"sift_Base1k_NEW"'::regclass, 'v_New');
+ drop_quantization 
+-------------------
+ 
 (1 row)
 

--- a/test/sql/hnsw_pq.sql
+++ b/test/sql/hnsw_pq.sql
@@ -13,28 +13,29 @@ SELECT '{84,1,4,128,255}'::INT[]::pqvec;
 -- Test PQVec type
 SELECT '{84,1,4,128,256}'::pqvec;
 -- Verify wrong argument assertions
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'nonexistant', 10, 32, 'l2sq');
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1001, 32, 'l2sq');
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 33, 'l2sq');
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sqz');
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 32, 'l2sq');
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 0, 'l2sq');
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'nonexistant', 10, 32, 'l2sq', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1001, 32, 'l2sq', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 33, 'l2sq', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sqz', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 32, 'l2sq', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 257, 0, 'l2sq', 0);
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 256, 0, 'l2sq', 10);
 \set ON_ERROR_STOP on
 
 -- This should create codebook[1][1][128]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1, 1, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 1, 1, 'l2sq', 0) as codebook \gset
 SELECT array_length(:'codebook'::REAL[][][], 1);
 SELECT array_length(:'codebook'::REAL[][][], 2);
 SELECT array_length(:'codebook'::REAL[][][], 3);
 
 -- This should create codebook[1][10][128]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 1, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 1, 'l2sq', 0) as codebook \gset
 SELECT array_length(:'codebook'::REAL[][][], 1);
 SELECT array_length(:'codebook'::REAL[][][], 2);
 SELECT array_length(:'codebook'::REAL[][][], 3);
 
 -- This should create codebook[32][10][4]
-SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sq') as codebook \gset
+SELECT _lantern_internal.create_pq_codebook('sift_base1k'::regclass, 'v', 10, 32, 'l2sq', 0) as codebook \gset
 SELECT array_length(:'codebook'::REAL[][][], 1);
 SELECT array_length(:'codebook'::REAL[][][], 2);
 SELECT array_length(:'codebook'::REAL[][][], 3);
@@ -55,8 +56,8 @@ UPDATE _lantern_internal._codebook_sift_base1k_v SET centroid_id=2 WHERE centroi
 INSERT INTO _lantern_internal._codebook_sift_base1k_v (subvector_id, centroid_id, c) VALUES (1, 1, '{1,2,3,4}');
 
 -- Validate that compressing invalid vector raises an error
-SELECT decompress_vector('{}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
-SELECT decompress_vector('{1,2,3}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
+SELECT dequantize_vector('{}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
+SELECT dequantize_vector('{1,2,3}'::pqvec, '_lantern_internal._codebook_sift_base1k_v'::regclass);
 \set ON_ERROR_STOP on
 
 -- Compression and Decompression
@@ -64,13 +65,13 @@ SELECT decompress_vector('{1,2,3}'::pqvec, '_lantern_internal._codebook_sift_bas
 SELECT v as v1 FROM sift_base1k WHERE id=1 \gset
 SELECT v_pq as v1_pq FROM sift_base1k WHERE id=1 \gset
 SELECT quantize_vector(:'v1', '_lantern_internal._codebook_sift_base1k_v'::regclass, 'l2sq') as compressed \gset
-SELECT decompress_vector(:'v1_pq', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_1 \gset
-SELECT decompress_vector(:'compressed', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_2 \gset
+SELECT dequantize_vector(:'v1_pq', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_1 \gset
+SELECT dequantize_vector(:'compressed', '_lantern_internal._codebook_sift_base1k_v'::regclass) as decompressed_2 \gset
 SELECT l2sq_dist(:'decompressed_1', :'decompressed_2');
 
 -- Test recall for quantized vs non quantized vectors
 ALTER TABLE sift_base1k ADD COLUMN v_pq_dec REAL[];
-UPDATE sift_base1k SET v_pq_dec=decompress_vector(v_pq, '_lantern_internal._codebook_sift_base1k_v');
+UPDATE sift_base1k SET v_pq_dec=dequantize_vector(v_pq, '_lantern_internal._codebook_sift_base1k_v');
 -- Calculate recall over original vector
 SELECT (calculate_table_recall('sift_base1k', 'sift_query1k', 'sift_truth1k', 'v', 10, 100) -
        calculate_table_recall('sift_base1k', 'sift_query1k', 'sift_truth1k', 'v_pq_dec', 10, 100)) as recall_diff \gset
@@ -95,3 +96,30 @@ SELECT COUNT(DISTINCT subvector_id) FROM _lantern_internal._codebook_sift_base1k
 SELECT COUNT(DISTINCT centroid_id) FROM _lantern_internal._codebook_sift_base1k_v_pq_dec;
 SELECT COUNT(*) FROM _lantern_internal._codebook_sift_base1k_v_pq_dec;
 SELECT array_length(c, 1) FROM _lantern_internal._codebook_sift_base1k_v_pq_dec LIMIT 1;
+
+-- Test that resources are being cleared correctly
+SELECT drop_quantization('sift_base1k'::regclass, 'v');
+SELECT drop_quantization('sift_base1k'::regclass, 'v_pq_dec');
+SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'sift_base1k';
+SELECT table_name FROM information_schema.tables WHERE table_schema = '_lantern_internal';
+
+-- Test quantization over subset of data
+SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'l2sq', 500);
+SELECT COUNT(DISTINCT subvector_id) FROM _lantern_internal._codebook_sift_base1k_v;
+SELECT COUNT(DISTINCT centroid_id) FROM _lantern_internal._codebook_sift_base1k_v;
+SELECT COUNT(*) FROM _lantern_internal._codebook_sift_base1k_v;
+SELECT array_length(c, 1) FROM _lantern_internal._codebook_sift_base1k_v LIMIT 1;
+
+-- Test quantization with mixed case and schema qualified table name
+SELECT id, v AS "v_New" into "sift_Base1k_NEW" FROM sift_base1k;
+SELECT quantize_table('"public"."sift_Base1k_NEW"'::regclass, 'v_New', 10, 32, 'l2sq');
+SELECT array_length(
+              dequantize_vector(
+                     quantize_vector(
+                       (SELECT "v_New" FROM "sift_Base1k_NEW" WHERE id=1), 
+                       '_lantern_internal."_codebook_sift_Base1k_NEW_v_New"'::regclass, 
+                       'l2sq'),  
+              '_lantern_internal."_codebook_sift_Base1k_NEW_v_New"'::regclass),
+              1
+       );
+SELECT drop_quantization('"sift_Base1k_NEW"'::regclass, 'v_New');


### PR DESCRIPTION
- Add drop_quantization API that deletes all PQ-quantization resources associated with a table
- Make sure all quantization resources and table hooks are deleted when the lantern extension is deleted
- Current api has quantize_vector but decompress_vector. switch to quantize/dequantize language
- Make quantize_table work with all kinds of table names and formattings
- Allow quantizing subset of a table