### PR TITLE
Adding deploy with stitch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![test](https://github.com/lanterndata/lantern/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/github/lanterndata/lantern/branch/main/graph/badge.svg)](https://codecov.io/github/lanterndata/lantern)
 [![Run on Replit](https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit)](https://replit.com/@lanterndata/lantern-playground#.replit)
-[![Deploy to AWS using Stitch](https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7)(https://deploy.stitch.tech/stitch/lantern)
+[![Deploy to AWS using Stitch](https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7)](https://deploy.stitch.tech/stitch/lantern)
 
 Lantern is an open-source PostgreSQL database extension to store vector data, generate embeddings, and handle vector search operations.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![test](https://github.com/lanterndata/lantern/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/github/lanterndata/lantern/branch/main/graph/badge.svg)](https://codecov.io/github/lanterndata/lantern)
 [![Run on Replit](https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit)](https://replit.com/@lanterndata/lantern-playground#.replit)
-[![Deploy to AWS using Stitch]([https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit](https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7))](https://deploy.stitch.tech/stitch/lantern)
+[![Deploy to AWS using Stitch](https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7)(https://deploy.stitch.tech/stitch/lantern)
 
 Lantern is an open-source PostgreSQL database extension to store vector data, generate embeddings, and handle vector search operations.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![test](https://github.com/lanterndata/lantern/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lantern/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/github/lanterndata/lantern/branch/main/graph/badge.svg)](https://codecov.io/github/lanterndata/lantern)
 [![Run on Replit](https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit)](https://replit.com/@lanterndata/lantern-playground#.replit)
+[![Deploy to AWS using Stitch]([https://img.shields.io/badge/Run%20on-Replit-blue?logo=replit](https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7))](https://deploy.stitch.tech/stitch/lantern)
 
 Lantern is an open-source PostgreSQL database extension to store vector data, generate embeddings, and handle vector search operations.
 


### PR DESCRIPTION
Adds a deploy with Stitch badge to the README.
<img width="613" alt="image" src="https://github.com/lanterndata/lantern/assets/8139394/2c775347-801b-4e02-90d8-3409ff5b4b21">

Hey I'm Raj from Stitch (YC W24) and we are building installers for opensource software. We feel like Lantern could really make use of this.

Here is a short video demo:

https://www.loom.com/share/9e205e26abd0467e97de861b50ba20be

The Stitch installer essentially creates infra on the user's cloud and runs a script to install Lantern. We have written the install script using the instructions on the readme. We will be fully opensourcing the Stitch installer so that it is transparent to users exactly what is being run on their cloud.

Please let me know if you have any questions.