### PR TITLE
Call external index function and import created index file on BuildIndex if external=true

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -372,7 +372,7 @@ static void InitBuildState(ldb_HnswBuildState *buildstate, Relation heap, Relati
     buildstate->columnType = GetIndexColumnType(index);
     buildstate->dimensions = GetHnswIndexDimensions(index, indexInfo);
     buildstate->index_file_path = ldb_HnswGetIndexFilePath(index);
-    buildstate->external = ldb_HnswGetExternal(index);
+    buildstate->parallel = ldb_HnswGetParallel(index);
 
     // If a dimension wasn't specified try to infer it
     if(heap != NULL && buildstate->dimensions < 1) {
@@ -472,7 +472,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     elog(INFO, "done init usearch index");
     assert(error == NULL);
 
-    if(buildstate->external) {
+    if(buildstate->parallel) {
         buildstate->index_file_path = ldb_crete_external_index_file(&opts, heap, index);
     }
 
@@ -574,7 +574,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
         pfree(tmp_index_file_path);
     }
 
-    if(buildstate->external) {
+    if(buildstate->parallel) {
         unlink(buildstate->index_file_path);
     }
 

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -19,6 +19,7 @@ typedef struct
     int            dimensions;
     HnswColumnType columnType;
     char          *index_file_path;
+    bool           external;
 
     /* Statistics */
     double tuples_indexed;
@@ -37,5 +38,6 @@ void              ldb_ambuildunlogged(Relation index);
 int               GetHnswIndexDimensions(Relation index, IndexInfo *indexInfo);
 void              CheckHnswIndexDimensions(Relation index, Datum arrayDatum, int deimensions);
 void              ldb_reindex_external_index(Oid indrelid);
+char             *ldb_crete_external_index_file(usearch_init_options_t *opts, Relation table_heap, Relation index);
 // todo: does this render my check unnecessary
 #endif  // LDB_HNSW_BUILD_H

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -19,7 +19,7 @@ typedef struct
     int            dimensions;
     HnswColumnType columnType;
     char          *index_file_path;
-    bool           external;
+    bool           parallel;
 
     /* Statistics */
     double tuples_indexed;

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -79,6 +79,13 @@ char *ldb_HnswGetIndexFilePath(Relation index)
     return (char *)opts + opts->experimantal_index_path_offset;
 }
 
+bool ldb_HnswGetExternal(Relation index)
+{
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
+    if(opts) return opts->external;
+    return false;
+}
+
 bool ldb_HnswGetPq(Relation index)
 {
     ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
@@ -122,6 +129,7 @@ bytea *ldb_amoptions(Datum reloptions, bool validate)
         {"ef_construction", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef_construction)},
         {"ef", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef)},
         {"pq", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, pq)},
+        {"external", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, external)},
         {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(ldb_HnswOptions, experimantal_index_path_offset)},
     };
 
@@ -216,6 +224,16 @@ void _PG_init(void)
                        "pq",
                        "Whether or not use to quantized table codebook for index construction. Assumes codebook is "
                        "called [tablename]_pq_codebook",
+                       false
+#if PG_VERSION_NUM >= 130000
+                       ,
+                       AccessExclusiveLock
+#endif
+
+    );
+    add_bool_reloption(ldb_hnsw_index_withopts,
+                       "external",
+                       "Whether or not use lantern_extras' external index creation",
                        false
 #if PG_VERSION_NUM >= 130000
                        ,

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -79,10 +79,10 @@ char *ldb_HnswGetIndexFilePath(Relation index)
     return (char *)opts + opts->experimantal_index_path_offset;
 }
 
-bool ldb_HnswGetExternal(Relation index)
+bool ldb_HnswGetParallel(Relation index)
 {
     ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
-    if(opts) return opts->external;
+    if(opts) return opts->parallel;
     return false;
 }
 
@@ -129,7 +129,7 @@ bytea *ldb_amoptions(Datum reloptions, bool validate)
         {"ef_construction", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef_construction)},
         {"ef", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef)},
         {"pq", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, pq)},
-        {"external", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, external)},
+        {"parallel", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, parallel)},
         {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(ldb_HnswOptions, experimantal_index_path_offset)},
     };
 
@@ -232,8 +232,8 @@ void _PG_init(void)
 
     );
     add_bool_reloption(ldb_hnsw_index_withopts,
-                       "external",
-                       "Whether or not use lantern_extras' external index creation",
+                       "parallel",
+                       "Whether or not use lantern_extras' parallel index creation",
                        false
 #if PG_VERSION_NUM >= 130000
                        ,

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -36,6 +36,7 @@ typedef struct ldb_HnswOptions
     int   ef_construction;
     int   ef;
     bool  pq;
+    bool  external;
     int   experimantal_index_path_offset;
 } ldb_HnswOptions;
 
@@ -45,6 +46,7 @@ int                   ldb_HnswGetEfConstruction(Relation index);
 int                   ldb_HnswGetEf(Relation index);
 char*                 ldb_HnswGetIndexFilePath(Relation index);
 bool                  ldb_HnswGetPq(Relation index);
+bool                  ldb_HnswGetExternal(Relation index);
 usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index);
 
 bytea* ldb_amoptions(Datum reloptions, bool validate);

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -36,7 +36,7 @@ typedef struct ldb_HnswOptions
     int   ef_construction;
     int   ef;
     bool  pq;
-    bool  external;
+    bool  parallel;
     int   experimantal_index_path_offset;
 } ldb_HnswOptions;
 
@@ -46,7 +46,7 @@ int                   ldb_HnswGetEfConstruction(Relation index);
 int                   ldb_HnswGetEf(Relation index);
 char*                 ldb_HnswGetIndexFilePath(Relation index);
 bool                  ldb_HnswGetPq(Relation index);
-bool                  ldb_HnswGetExternal(Relation index);
+bool                  ldb_HnswGetParallel(Relation index);
 usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index);
 
 bytea* ldb_amoptions(Datum reloptions, bool validate);

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -174,3 +174,90 @@ EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
+SELECT drop_quantization('sift_base1k'::regclass, 'v');
+ drop_quantization 
+-------------------
+ 
+(1 row)
+
+DROP INDEX hnsw_cos_index_pq;
+-- Create using CREATE INDEX syntax with defaults
+CREATE INDEX hnsw_l2_index ON sift_base1k USING lantern_hnsw(v) WITH (external=true);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_l2_index on sift_base1k
+         Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
+INFO:  validate_index() start for hnsw_l2_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+DROP INDEX hnsw_l2_index;
+-- Create using CREATE INDEX syntax with params
+CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_cos_index on sift_base1k
+         Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT _lantern_internal.validate_index('hnsw_cos_index', false);
+INFO:  validate_index() start for hnsw_cos_index
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+DROP INDEX hnsw_cos_index;
+-- Create using CREATE INDEX syntax with pq (should error)
+\set ON_ERROR_STOP off
+CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+ERROR:  PQ-codebook for relation "sift_base1k" not found
+\set ON_ERROR_STOP on
+SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'cos');
+INFO:  Table scanned. Dataset size 1000
+INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
+INFO:  Codebooks created
+INFO:  Compressing vectors...
+ quantize_table 
+----------------
+ 
+(1 row)
+
+CREATE INDEX hnsw_cos_index_pq ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_cos_index_pq on sift_base1k
+         Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT _lantern_internal.validate_index('hnsw_cos_index_pq', false);
+INFO:  validate_index() start for hnsw_cos_index_pq
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
+DROP INDEX hnsw_cos_index_pq;

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -182,7 +182,7 @@ SELECT drop_quantization('sift_base10k'::regclass, 'v');
 
 DROP INDEX hnsw_cos_index_pq;
 -- Create using CREATE INDEX syntax with defaults
-CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (external=true);
+CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (parallel=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 10000 vectors
@@ -204,7 +204,7 @@ INFO:  validate_index() done, no issues found.
 
 DROP INDEX hnsw_l2_index;
 -- Create using CREATE INDEX syntax with params
-CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, parallel=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 10000 vectors
@@ -227,7 +227,7 @@ INFO:  validate_index() done, no issues found.
 DROP INDEX hnsw_cos_index;
 -- Create using CREATE INDEX syntax with pq (should error)
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, parallel=true, pq=true);
 ERROR:  PQ-codebook for relation "sift_base10k" not found
 \set ON_ERROR_STOP on
 SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
@@ -240,7 +240,7 @@ INFO:  Compressing vectors...
  
 (1 row)
 
-CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, parallel=true, pq=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 10000 vectors

--- a/test/expected/hnsw_extras.out
+++ b/test/expected/hnsw_extras.out
@@ -1,22 +1,22 @@
 ------------------------------------------------------------------------------
 -- Test Functions exported from lantern_extras extension
 ------------------------------------------------------------------------------
-\ir utils/sift1k_array.sql
-CREATE TABLE IF NOT EXISTS sift_base1k (
-    id SERIAL,
-    v REAL[]
+\ir utils/sift10k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base10k (
+     id SERIAL PRIMARY KEY,
+     v REAL[128]
 );
-COPY sift_base1k (v) FROM '/tmp/lantern/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+\copy sift_base10k (v) FROM '/tmp/lantern/vector_datasets/siftsmall_base_arrays.csv' with csv;
 \set ON_ERROR_STOP off
 CREATE EXTENSION lantern_extras;
 -- Validate error on invalid params
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'invalid_metric',  3, 10, 10, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'invalid_metric',  3, 10, 10, 10);
 ERROR:  Invalid metric invalid_metric
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, -1, 10, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, -1, 10, 10);
 ERROR:  m should be in range [2, 128]
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, -2, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, 10, -2, 10);
 ERROR:  ef_construction should be in range [1, 400]
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, 10, 10, -1);
 ERROR:  ef should be in range [1, 400]
 -- Validate error on empty table
 CREATE TABLE empty (v REAL[]);
@@ -24,44 +24,44 @@ SELECT lantern_create_external_index('v', 'empty');
 ERROR:  Cannot create an external index on empty table
 \set ON_ERROR_STOP on
 -- Create with defaults
-SELECT lantern_create_external_index('v', 'sift_base1k');
+SELECT lantern_create_external_index('v', 'sift_base10k');
  lantern_create_external_index 
 -------------------------------
  
 (1 row)
 
-SELECT _lantern_internal.validate_index('sift_base1k_v_idx', false);
-INFO:  validate_index() start for sift_base1k_v_idx
+SELECT _lantern_internal.validate_index('sift_base10k_v_idx', false);
+INFO:  validate_index() start for sift_base10k_v_idx
 INFO:  validate_index() done, no issues found.
  validate_index 
 ----------------
  
 (1 row)
 
-SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+SELECT v AS v777 FROM sift_base10k WHERE id = 777 \gset
 -- Validate that using corresponding operator triggers index scan
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <-> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using sift_base1k_v_idx on sift_base1k
+   ->  Index Scan using sift_base10k_v_idx on sift_base10k
          Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
 SET lantern.pgvector_compat=FALSE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <?> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using sift_base1k_v_idx on sift_base1k
+   ->  Index Scan using sift_base10k_v_idx on sift_base10k
          Order By: (v <?> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
 SET lantern.pgvector_compat=TRUE;
-DROP INDEX sift_base1k_v_idx;
+DROP INDEX sift_base10k_v_idx;
 -- Create with params
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, false, 'hnsw_cos_index');
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, false, 'hnsw_cos_index');
  lantern_create_external_index 
 -------------------------------
  
@@ -76,20 +76,20 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index on sift_base1k
+   ->  Index Scan using hnsw_cos_index on sift_base10k
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
 SET lantern.pgvector_compat=FALSE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <?> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index on sift_base1k
+   ->  Index Scan using hnsw_cos_index on sift_base10k
          Order By: (v <?> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
@@ -111,11 +111,11 @@ INFO:  validate_index() done, no issues found.
 
 -- Validate that using corresponding operator triggers index scan
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index on sift_base1k
+   ->  Index Scan using hnsw_cos_index on sift_base10k
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
@@ -124,12 +124,12 @@ SET client_min_messages=ERROR;
 DROP INDEX hnsw_cos_index;
 -- Verify error that codebook does not exist
 \set ON_ERROR_STOP off
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
-ERROR:  Codebook table "_lantern_internal"."pq_sift_base1k_v" does not exist
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
+ERROR:  Codebook table "_lantern_internal"."pq_sift_base10k_v" does not exist
 \set ON_ERROR_STOP on
-SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'cos');
-INFO:  Table scanned. Dataset size 1000
-INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
+SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
+INFO:  Table scanned. Dataset size 10000
+INFO:  Starting k-means over dataset with (subvectors=4, clusters=5)
 INFO:  Codebooks created
 INFO:  Compressing vectors...
  quantize_table 
@@ -137,7 +137,7 @@ INFO:  Compressing vectors...
  
 (1 row)
 
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
  lantern_create_external_index 
 -------------------------------
  
@@ -166,15 +166,15 @@ INFO:  validate_index() done, no issues found.
 (1 row)
 
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index_pq on sift_base1k
+   ->  Index Scan using hnsw_cos_index_pq on sift_base10k
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
-SELECT drop_quantization('sift_base1k'::regclass, 'v');
+SELECT drop_quantization('sift_base10k'::regclass, 'v');
  drop_quantization 
 -------------------
  
@@ -182,15 +182,15 @@ SELECT drop_quantization('sift_base1k'::regclass, 'v');
 
 DROP INDEX hnsw_cos_index_pq;
 -- Create using CREATE INDEX syntax with defaults
-CREATE INDEX hnsw_l2_index ON sift_base1k USING lantern_hnsw(v) WITH (external=true);
+CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (external=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+INFO:  done saving 10000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <-> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_l2_index on sift_base1k
+   ->  Index Scan using hnsw_l2_index on sift_base10k
          Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
@@ -204,15 +204,15 @@ INFO:  validate_index() done, no issues found.
 
 DROP INDEX hnsw_l2_index;
 -- Create using CREATE INDEX syntax with params
-CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+INFO:  done saving 10000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index on sift_base1k
+   ->  Index Scan using hnsw_cos_index on sift_base10k
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 
@@ -227,12 +227,12 @@ INFO:  validate_index() done, no issues found.
 DROP INDEX hnsw_cos_index;
 -- Create using CREATE INDEX syntax with pq (should error)
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
-ERROR:  PQ-codebook for relation "sift_base1k" not found
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+ERROR:  PQ-codebook for relation "sift_base10k" not found
 \set ON_ERROR_STOP on
-SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'cos');
-INFO:  Table scanned. Dataset size 1000
-INFO:  Starting k-means over dataset with (subvectors=32, clusters=10)
+SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
+INFO:  Table scanned. Dataset size 10000
+INFO:  Starting k-means over dataset with (subvectors=4, clusters=5)
 INFO:  Codebooks created
 INFO:  Compressing vectors...
  quantize_table 
@@ -240,15 +240,15 @@ INFO:  Compressing vectors...
  
 (1 row)
 
-CREATE INDEX hnsw_cos_index_pq ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true, pq=true);
 INFO:  done init usearch index
 INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+INFO:  done saving 10000 vectors
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using hnsw_cos_index_pq on sift_base1k
+   ->  Index Scan using hnsw_cos_index_pq on sift_base10k
          Order By: (v <=> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
 (3 rows)
 

--- a/test/sql/hnsw_extras.sql
+++ b/test/sql/hnsw_extras.sql
@@ -68,21 +68,21 @@ SELECT drop_quantization('sift_base10k'::regclass, 'v');
 DROP INDEX hnsw_cos_index_pq;
 
 -- Create using CREATE INDEX syntax with defaults
-CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (external=true);
+CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (parallel=true);
 EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <-> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
 DROP INDEX hnsw_l2_index;
 -- Create using CREATE INDEX syntax with params
-CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, parallel=true);
 EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_cos_index', false);
 DROP INDEX hnsw_cos_index;
 -- Create using CREATE INDEX syntax with pq (should error)
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, parallel=true, pq=true);
 \set ON_ERROR_STOP on
 SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
-CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, parallel=true, pq=true);
 EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_cos_index_pq', false);
 DROP INDEX hnsw_cos_index_pq;

--- a/test/sql/hnsw_extras.sql
+++ b/test/sql/hnsw_extras.sql
@@ -2,15 +2,15 @@
 -- Test Functions exported from lantern_extras extension
 ------------------------------------------------------------------------------
 
-\ir utils/sift1k_array.sql
+\ir utils/sift10k_array.sql
 
 \set ON_ERROR_STOP off
 CREATE EXTENSION lantern_extras;
 -- Validate error on invalid params
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'invalid_metric',  3, 10, 10, 10);
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, -1, 10, 10);
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, -2, 10);
-SELECT lantern_create_external_index('v','sift_base1k', 'public', 'l2sq',  3, 10, 10, -1);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'invalid_metric',  3, 10, 10, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, -1, 10, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, 10, -2, 10);
+SELECT lantern_create_external_index('v','sift_base10k', 'public', 'l2sq',  3, 10, 10, -1);
 
 -- Validate error on empty table
 CREATE TABLE empty (v REAL[]);
@@ -18,27 +18,27 @@ SELECT lantern_create_external_index('v', 'empty');
 \set ON_ERROR_STOP on
 
 -- Create with defaults
-SELECT lantern_create_external_index('v', 'sift_base1k');
-SELECT _lantern_internal.validate_index('sift_base1k_v_idx', false);
+SELECT lantern_create_external_index('v', 'sift_base10k');
+SELECT _lantern_internal.validate_index('sift_base10k_v_idx', false);
 
-SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+SELECT v AS v777 FROM sift_base10k WHERE id = 777 \gset
 -- Validate that using corresponding operator triggers index scan
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <-> :'v777' LIMIT 10;
 
 SET lantern.pgvector_compat=FALSE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <?> :'v777' LIMIT 10;
 SET lantern.pgvector_compat=TRUE;
-DROP INDEX sift_base1k_v_idx;
+DROP INDEX sift_base10k_v_idx;
 
 -- Create with params
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, false, 'hnsw_cos_index');
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, false, 'hnsw_cos_index');
 SELECT _lantern_internal.validate_index('hnsw_cos_index', false);
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 
 SET lantern.pgvector_compat=FALSE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <?> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <?> :'v777' LIMIT 10;
 SET lantern.pgvector_compat=TRUE;
 
 -- -- Reindex external index
@@ -47,43 +47,43 @@ SELECT _lantern_internal.validate_index('hnsw_cos_index', false);
 
 -- Validate that using corresponding operator triggers index scan
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 
 -- Create PQ Index
 SET client_min_messages=ERROR;
 DROP INDEX hnsw_cos_index;
 -- Verify error that codebook does not exist
 \set ON_ERROR_STOP off
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
 \set ON_ERROR_STOP on
-SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'cos');
-SELECT lantern_create_external_index('v', 'sift_base1k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
+SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
+SELECT lantern_create_external_index('v', 'sift_base10k', 'public', 'cos', 128, 10, 10, 10, true, 'hnsw_cos_index_pq');
 SELECT _lantern_internal.validate_index('hnsw_cos_index_pq', false);
 SELECT lantern_reindex_external_index('hnsw_cos_index_pq');
 SELECT _lantern_internal.validate_index('hnsw_cos_index_pq', false);
 SET lantern.pgvector_compat=TRUE;
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 
-SELECT drop_quantization('sift_base1k'::regclass, 'v');
+SELECT drop_quantization('sift_base10k'::regclass, 'v');
 DROP INDEX hnsw_cos_index_pq;
 
 -- Create using CREATE INDEX syntax with defaults
-CREATE INDEX hnsw_l2_index ON sift_base1k USING lantern_hnsw(v) WITH (external=true);
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+CREATE INDEX hnsw_l2_index ON sift_base10k USING lantern_hnsw(v) WITH (external=true);
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <-> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_l2_index', false);
 DROP INDEX hnsw_l2_index;
 -- Create using CREATE INDEX syntax with params
-CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true);
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true);
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_cos_index', false);
 DROP INDEX hnsw_cos_index;
 -- Create using CREATE INDEX syntax with pq (should error)
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_cos_index ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
+CREATE INDEX hnsw_cos_index ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
 \set ON_ERROR_STOP on
-SELECT quantize_table('sift_base1k'::regclass, 'v', 10, 32, 'cos');
-CREATE INDEX hnsw_cos_index_pq ON sift_base1k USING lantern_hnsw(v dist_cos_ops) WITH (m=12, ef=128, ef_construction=32, external=true, pq=true);
-EXPLAIN (COSTS FALSE) SELECT id FROM sift_base1k order by v <=> :'v777' LIMIT 10;
+SELECT quantize_table('sift_base10k'::regclass, 'v', 5, 4, 'cos');
+CREATE INDEX hnsw_cos_index_pq ON sift_base10k USING lantern_hnsw(v dist_cos_ops) WITH (m=4, ef=128, ef_construction=32, external=true, pq=true);
+EXPLAIN (COSTS FALSE) SELECT id FROM sift_base10k order by v <=> :'v777' LIMIT 10;
 SELECT _lantern_internal.validate_index('hnsw_cos_index_pq', false);
 DROP INDEX hnsw_cos_index_pq;
 


### PR DESCRIPTION
- Added new option to index `bool external`
- If external is true we will call `_create_external_index` function from lantern_extras
- The multicore index creation will be done in Rust side, index will be saved in file and file path will be returned from the function
- We will then use the file path as `_experimental_index_path` option in our `BuildIndex` function to import that file