### PR TITLE
External indexing via tcp socket

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
           submodules: "recursive"
       - name: Build
         id: build
-        run: sudo sh -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ENABLE_COVERAGE=$ENABLE_COVERAGE ./ci/scripts/build.sh"
+        run: sudo sh -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ENABLE_COVERAGE=$ENABLE_COVERAGE INSTALL_CLI=1 ./ci/scripts/build.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -47,13 +47,16 @@ jobs:
           PG_VERSION: ${{ matrix.postgres }}
           ENABLE_COVERAGE: ${{ (startsWith(matrix.os, 'ubuntu') && matrix.postgres == 15) && '1' || '0' }}
         if: ${{ !startsWith(matrix.os, 'mac') }}
-      # add a step to run integration tests
+      # integration tests
+      - name: Set LANTERN_CLI_PATH variable
+        run: echo "LANTERN_CLI_PATH=/tmp/bin/lantern-cli" >> $GITHUB_ENV
+        if: ${{ !startsWith(matrix.os, 'mac') }}
       - name: Run integration tests linux
         id: integration-test-linux
         run: |
           # pytest tries to open files with full path and so 'work' home folder must be listable by postgres for it to work
           sudo chmod +x /home/runner && \
-          sudo su postgres -c "/tmp/lantern/cienv/bin/python ./scripts/integration_tests.py" &&\
+          sudo su postgres -c "LANTERN_CLI_PATH=${{ env.LANTERN_CLI_PATH }} /tmp/lantern/cienv/bin/python ./scripts/integration_tests.py" &&\
           echo "Done with integration tests"
         env:
           PG_VERSION: ${{ matrix.postgres }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 
-set(LANTERN_VERSION 0.3.1)
+set(LANTERN_VERSION 0.3.2)
 
 project(
   LanternDB
@@ -250,6 +250,7 @@ endif()
 
 set (_update_files
   sql/updates/0.3.0--0.3.1.sql
+  sql/updates/0.3.1--0.3.2.sql
 )
 
 # Generate version information for the binary

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -66,8 +66,7 @@ function install_platform_specific_dependencies() {
     if [[ "$INSTALL_CLI" = "1" ]]
     then
       setup_rust
-      # TODO:: change branch after PR merge
-      ORT_STRATEGY=system cargo install --git https://github.com/lanterndata/lantern_extras.git --branch varik/external-indexing-server --debug --bin lantern-cli --root /tmp
+      ORT_STRATEGY=system cargo install --git https://github.com/lanterndata/lantern_extras.git --branch main --debug --bin lantern-cli --root /tmp
     fi
 
   popd

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -31,7 +31,7 @@ function setup_postgres() {
 function setup_rust() {
   curl -k -o /tmp/rustup.sh https://sh.rustup.rs
   chmod +x /tmp/rustup.sh
-  /tmp/rustup.sh -y
+  /tmp/rustup.sh -y --default-toolchain=1.78.0
   . "$HOME/.cargo/env"
 }
 
@@ -66,6 +66,7 @@ function install_platform_specific_dependencies() {
     if [[ "$INSTALL_CLI" = "1" ]]
     then
       setup_rust
+      # TODO:: change branch after PR merge
       ORT_STRATEGY=system cargo install --git https://github.com/lanterndata/lantern_extras.git --branch varik/external-indexing-server --debug --bin lantern-cli --root /tmp
     fi
 

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -28,6 +28,13 @@ function setup_postgres() {
   echo "shared_preload_libraries = 'pg_cron' " >> /etc/postgresql/$PG_VERSION/main/postgresql.conf
 }
 
+function setup_rust() {
+  curl -k -o /tmp/rustup.sh https://sh.rustup.rs
+  chmod +x /tmp/rustup.sh
+  /tmp/rustup.sh -y
+  . "$HOME/.cargo/env"
+}
+
 function install_platform_specific_dependencies() {
   # Currently lantern_extras binaries are only available for Linux x86_64
   # We won't install onnxruntime as lantern_extras are used only for external index in tests
@@ -54,6 +61,13 @@ function install_platform_specific_dependencies() {
 
     apt install -y ruby-full
     gem install bundler
+
+    # We need lantern-cli only for tests
+    if [[ "$INSTALL_CLI" = "1" ]]
+    then
+      setup_rust
+      ORT_STRATEGY=system cargo install --git https://github.com/lanterndata/lantern_extras.git --branch varik/external-indexing-server --debug --bin lantern-cli --root /tmp
+    fi
 
   popd
 }

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -591,9 +591,12 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     UpdateProgress(PROGRESS_CREATEIDX_PHASE, LDB_PROGRESS_HNSW_PHASE_LOAD);
     StoreExternalIndex(index, &metadata, MAIN_FORKNUM, result_buf, &opts, buildstate->dimensions, num_added_vectors);
 
-    munmap_ret = munmap(result_buf, index_file_stat.st_size);
-    assert(munmap_ret == 0);
-    LDB_UNUSED(munmap_ret);
+    if(!buildstate->external) {
+        munmap_ret = munmap(result_buf, index_file_stat.st_size);
+        assert(munmap_ret == 0);
+        LDB_UNUSED(munmap_ret);
+    }
+
     close(index_file_fd);
 
     if(buildstate->external) {

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -29,9 +29,6 @@
 #include <utils/palloc.h>
 #include <utils/snapmgr.h>
 #include <utils/syscache.h>
-// sockets
-#include <arpa/inet.h>
-#include <sys/socket.h>
 
 #include "usearch.h"
 
@@ -43,6 +40,7 @@
 
 #include "bench.h"
 #include "external_index.h"
+#include "external_index_socket.h"
 #include "hnsw.h"
 #include "hnsw/pqtable.h"
 #include "hnsw/retriever.h"
@@ -81,154 +79,6 @@
 #define UpdateProgress(index, val) ((void)val)
 #endif
 
-// ============= EXTERNAL INDEXING ============
-#define EXTERNAL_INDEX_MAGIC_MSG_SIZE 4
-#define EXTERNAL_INDEX_INIT_MSG       0x13333337
-#define EXTERNAL_INDEX_END_MSG        0x31333337
-#define EXTERNAL_INDEX_ERR_MSG        0x37333337
-#define BUFFER_SIZE                   1024 * 1024 * 10  // 10MB
-
-typedef struct external_index_params_t
-{
-    uint32                pq;
-    usearch_metric_kind_t metric_kind;
-    usearch_scalar_kind_t quantization;
-    uint32                dim;
-    uint32                m;
-    uint32                ef_construction;
-    uint32                ef;
-    uint32                num_centroids;
-    uint32                num_subvectors;
-    uint32                estimated_capcity;
-
-} external_index_params_t;
-
-static bool is_little_endian()
-{
-    int i = 1;
-
-    return *((char *)&i) == 1;
-}
-
-#define BYTES_TO_UINT32(bytes) \
-    ((uint32)(bytes[ 0 ]) + ((uint32)(bytes[ 1 ]) << 8) + ((uint32)(bytes[ 2 ]) << 16) + ((uint32)(bytes[ 3 ]) << 24))
-
-#define BYTES_TO_UINT64(bytes)                                                                                        \
-    ((uint64)(bytes[ 0 ]) + ((uint64)(bytes[ 1 ]) << 8) + ((uint64)(bytes[ 2 ]) << 16) + ((uint64)(bytes[ 3 ]) << 24) \
-     + ((uint64)(bytes[ 4 ]) << 32) + ((uint64)(bytes[ 5 ]) << 40) + ((uint64)(bytes[ 6 ]) << 48)                     \
-     + ((uint64)(bytes[ 7 ]) << 56))
-
-void check_external_index_response_error(uint32 client_fd, unsigned char *buffer, int32 size)
-{
-    if(size < 0) {
-        close(client_fd);
-        // elog(ERROR, "external index socket send failed with %s", strerror(errno));
-        elog(ERROR, "external index socket read failed");
-    }
-
-    if(size < sizeof(uint32)) return;
-
-    uint8 *bytes = (uint8 *)(buffer);
-    uint32 hdr = BYTES_TO_UINT32(bytes);
-
-    if(hdr != EXTERNAL_INDEX_ERR_MSG) return;
-
-    // append nullbyte
-    buffer[ size ] = '\0';
-    shutdown(client_fd, SHUT_RDWR);
-    close(client_fd);
-    elog(ERROR, "external index error: %s", buffer + EXTERNAL_INDEX_MAGIC_MSG_SIZE);
-}
-
-void check_external_index_request_error(uint32 client_fd, int32 bytes_written)
-{
-    if(bytes_written > 0) return;
-
-    shutdown(client_fd, SHUT_RDWR);
-    close(client_fd);
-    elog(ERROR, "external index socket send failed");
-}
-
-static void external_index_send_codebook(
-    uint32 client_fd, float *codebook, uint32 dimensions, uint32 num_centroids, uint32 num_subvectors)
-{
-    int           data_size = dimensions * sizeof(float);
-    int           bytes_written = -1;
-    unsigned char buf[ data_size ];
-
-    for(int i = 0; i < num_centroids; i++) {
-        memcpy(buf, &codebook[ i * dimensions ], data_size);
-        bytes_written = send(client_fd, buf, data_size, 0);
-        check_external_index_request_error(client_fd, bytes_written);
-    }
-
-    uint32 end_msg = EXTERNAL_INDEX_END_MSG;
-    bytes_written = send(client_fd, &end_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
-
-    check_external_index_request_error(client_fd, bytes_written);
-}
-
-static int create_external_index_session(const char                   *host,
-                                         int                           port,
-                                         const usearch_init_options_t *params,
-                                         const ldb_HnswBuildState     *buildstate,
-                                         uint32                        estimated_row_count)
-{
-    int                client_fd, status;
-    unsigned char      init_buf[ sizeof(external_index_params_t) + EXTERNAL_INDEX_MAGIC_MSG_SIZE ];
-    struct sockaddr_in serv_addr;
-    unsigned char      init_response[ 1024 ] = {0};
-
-    if((client_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-        elog(ERROR, "external index: socket creation failed");
-    }
-
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_port = htons(port);
-
-    if(inet_pton(AF_INET, host, &serv_addr.sin_addr) <= 0) {
-        elog(ERROR, "external index: invalid address");
-    }
-
-    if((status = connect(client_fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr))) < 0) {
-        elog(ERROR, "external index: connection with server failed");
-    }
-
-    external_index_params_t index_params = {
-        .pq = params->pq,
-        .metric_kind = params->metric_kind,
-        .quantization = params->quantization,
-        .dim = params->dimensions,
-        .m = params->connectivity,
-        .ef_construction = params->expansion_add,
-        .ef = params->expansion_search,
-        .num_centroids = params->num_centroids,
-        .num_subvectors = params->num_subvectors,
-        .estimated_capcity = estimated_row_count,
-    };
-
-    uint32 hdr_msg = EXTERNAL_INDEX_INIT_MSG;
-    memcpy(init_buf, &hdr_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE);
-    memcpy(init_buf + EXTERNAL_INDEX_MAGIC_MSG_SIZE, &index_params, sizeof(external_index_params_t));
-    uint32 bytes_written
-        = send(client_fd, init_buf, sizeof(external_index_params_t) + EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
-
-    check_external_index_request_error(client_fd, bytes_written);
-
-    if(params->pq) {
-        external_index_send_codebook(
-            client_fd, buildstate->pq_codebook, params->dimensions, params->num_centroids, params->num_subvectors);
-    }
-
-    uint32 buf_size = read(client_fd, &init_response, 1024);
-
-    check_external_index_response_error(client_fd, init_response, buf_size);
-
-    return client_fd;
-}
-
-// ============= EXTERNAL INDEXING END ============
-
 static void AddTupleToUsearchIndex(ItemPointer         tid,
                                    Datum               detoasted_vector,
                                    ldb_HnswBuildState *buildstate,
@@ -237,9 +87,6 @@ static void AddTupleToUsearchIndex(ItemPointer         tid,
     usearch_error_t       error = NULL;
     usearch_scalar_kind_t usearch_scalar;
     uint8                 scalar_bits = 32;
-    uint32                tuple_size, bytes_written;
-    // maximum tuple size can be 8kb (8192 byte) + 8 byte label
-    unsigned char tuple[ 8200 ];
 
     void *vector = DatumGetSizedArray(detoasted_vector, buildstate->columnType, buildstate->dimensions, false);
     switch(buildstate->columnType) {
@@ -262,11 +109,7 @@ static void AddTupleToUsearchIndex(ItemPointer         tid,
 
     if(buildstate->external_client_fd) {
         // send tuple over socket if this is external indexing
-        tuple_size = sizeof(usearch_label_t) + buildstate->dimensions * (scalar_bits / 8);
-        memcpy(tuple, &label, sizeof(usearch_label_t));
-        memcpy(tuple + sizeof(usearch_label_t), vector, tuple_size - sizeof(usearch_label_t));
-        bytes_written = send(buildstate->external_client_fd, tuple, tuple_size, 0);
-        check_external_index_request_error(buildstate->external_client_fd, bytes_written);
+        external_index_send_tuple(buildstate->external_client_fd, &label, vector, scalar_bits, buildstate->dimensions);
     } else if(buildstate->usearch_index != NULL) {
         size_t capacity = usearch_capacity(buildstate->usearch_index, &error);
         if(capacity == usearch_size(buildstate->usearch_index, &error)) {
@@ -677,11 +520,6 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
                  "maintenance_work_mem");
 
         if(buildstate->external) {
-            assert(is_little_endian());
-            elog(INFO,
-                 "connecting to external indexing daemon on %s:%d",
-                 ldb_external_index_host,
-                 ldb_external_index_port);
             buildstate->external_client_fd = create_external_index_session(
                 ldb_external_index_host, ldb_external_index_port, &opts, buildstate, estimated_row_count);
             assert(buildstate->external_client_fd > 0);
@@ -712,46 +550,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     if(buildstate->index_file_path) {
         index_file_fd = open(buildstate->index_file_path, O_RDONLY);
     } else if(buildstate->external) {
-        uint32        end_msg = EXTERNAL_INDEX_END_MSG;
-        unsigned char buffer[ sizeof(uint64_t) ];
-        int32         bytes_read, bytes_written;
-        uint64        index_size = 0, total_received = 0;
-
-        // send message indicating that we have finished streaming tuples
-        bytes_written = send(buildstate->external_client_fd, &end_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
-        check_external_index_request_error(buildstate->external_client_fd, bytes_written);
-
-        // read how many tuples have been indexed
-        bytes_read = read(buildstate->external_client_fd, buffer, sizeof(uint64));
-        check_external_index_response_error(buildstate->external_client_fd, buffer, bytes_read);
-        num_added_vectors = BYTES_TO_UINT64(buffer);
-
-        // read index file size
-        bytes_read = read(buildstate->external_client_fd, buffer, sizeof(uint64));
-        check_external_index_response_error(buildstate->external_client_fd, buffer, bytes_read);
-        index_size = BYTES_TO_UINT64(buffer);
-
-        result_buf = palloc0(index_size);
-
-        assert(result_buf != NULL);
-
-        // start reading index into buffer
-        while(total_received < index_size) {
-            bytes_read = read(buildstate->external_client_fd, result_buf + total_received, BUFFER_SIZE);
-
-            // Check for CTRL-C interrupts
-            CHECK_FOR_INTERRUPTS();
-
-            check_external_index_response_error(
-                buildstate->external_client_fd, (unsigned char *)result_buf + total_received, bytes_read);
-
-            if(bytes_read == 0) {
-                break;
-            }
-
-            total_received += bytes_read;
-        }
-
+        external_index_receive_index_file(buildstate->external_client_fd, &num_added_vectors, &result_buf);
     } else {
         // Save index into temporary file
         // To later mmap it into memory
@@ -782,7 +581,9 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     if(!buildstate->external) {
         fstat(index_file_fd, &index_file_stat);
         result_buf = mmap(NULL, index_file_stat.st_size, PROT_READ, MAP_PRIVATE, index_file_fd, 0);
-        assert(result_buf != MAP_FAILED);
+        if(result_buf == MAP_FAILED) {
+            elog(ERROR, "failed to mmap index file");
+        }
     }
     //****************************** mmap index to memory END ******************************//
 
@@ -796,7 +597,6 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     close(index_file_fd);
 
     if(buildstate->external) {
-        shutdown(buildstate->external_client_fd, SHUT_RDWR);
         close(buildstate->external_client_fd);
     }
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -90,16 +90,16 @@
 
 typedef struct external_index_params_t
 {
-    bool                  pq;
+    uint32                pq;
     usearch_metric_kind_t metric_kind;
     usearch_scalar_kind_t quantization;
-    uint32_t              dim;
-    uint32_t              m;
-    uint32_t              ef_construction;
-    uint32_t              ef;
-    uint32_t              num_centroids;
-    uint32_t              num_subvectors;
-    uint32_t              estimated_capcity;
+    uint32                dim;
+    uint32                m;
+    uint32                ef_construction;
+    uint32                ef;
+    uint32                num_centroids;
+    uint32                num_subvectors;
+    uint32                estimated_capcity;
 
 } external_index_params_t;
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -589,7 +589,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
 
     // save the index to WAL
     UpdateProgress(PROGRESS_CREATEIDX_PHASE, LDB_PROGRESS_HNSW_PHASE_LOAD);
-    StoreExternalIndex(index, &metadata, MAIN_FORKNUM, result_buf, &opts, num_added_vectors);
+    StoreExternalIndex(index, &metadata, MAIN_FORKNUM, result_buf, &opts, buildstate->dimensions, num_added_vectors);
 
     munmap_ret = munmap(result_buf, index_file_stat.st_size);
     assert(munmap_ret == 0);

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -19,6 +19,8 @@ typedef struct
     int            dimensions;
     HnswColumnType columnType;
     char          *index_file_path;
+    bool           external;
+    int            external_client_fd;
 
     /* Statistics */
     double tuples_indexed;

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -121,6 +121,7 @@ void StoreExternalIndex(Relation                index,
                         ForkNumber              forkNum,
                         char                   *data,
                         usearch_init_options_t *opts,
+                        uint32                  pg_dimension,
                         size_t                  num_added_vectors);
 
 // add the fully constructed index tuple to the index via wal

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -1,0 +1,226 @@
+#include <postgres.h>
+
+#include "external_index_socket.h"
+
+#include <arpa/inet.h>
+#include <hnsw/build.h>
+#include <miscadmin.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static bool is_little_endian()
+{
+    int i = 1;
+
+    return *((char *)&i) == 1;
+}
+
+static void set_read_timeout(uint32 client_fd, uint32 seconds)
+{
+    struct timeval timeout;
+
+    timeout.tv_sec = seconds;
+    timeout.tv_usec = 0;
+
+    if(setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout) < 0) {
+        elog(ERROR, "external index: failed to set receive timeout for socket");
+    }
+}
+
+static void set_write_timeout(uint32 client_fd, uint32 seconds)
+{
+    struct timeval timeout;
+
+    timeout.tv_sec = seconds;
+    timeout.tv_usec = 0;
+
+    if(setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof timeout) < 0) {
+        elog(ERROR, "external index: failed to set send timeout for socket");
+    }
+}
+
+void check_external_index_response_error(uint32 client_fd, unsigned char *buffer, int32 size)
+{
+    uint32 hdr;
+    if(size < 0) {
+        close(client_fd);
+        elog(ERROR, "external index socket read failed");
+    }
+
+    if(size < sizeof(uint32)) return;
+
+    memcpy(&hdr, buffer, sizeof(uint32));
+
+    if(hdr != EXTERNAL_INDEX_ERR_MSG) return;
+
+    // append nullbyte
+    buffer[ size ] = '\0';
+    close(client_fd);
+    elog(ERROR, "external index error: %s", buffer + EXTERNAL_INDEX_MAGIC_MSG_SIZE);
+}
+
+void check_external_index_request_error(uint32 client_fd, int32 bytes_written)
+{
+    if(bytes_written > 0) return;
+
+    close(client_fd);
+    elog(ERROR, "external index socket send failed");
+}
+
+void external_index_send_codebook(
+    uint32 client_fd, float *codebook, uint32 dimensions, uint32 num_centroids, uint32 num_subvectors)
+{
+    int           data_size = dimensions * sizeof(float);
+    int           bytes_written = -1;
+    unsigned char buf[ data_size ];
+
+    for(int i = 0; i < num_centroids; i++) {
+        memcpy(buf, &codebook[ i * dimensions ], data_size);
+        bytes_written = send(client_fd, buf, data_size, 0);
+        check_external_index_request_error(client_fd, bytes_written);
+    }
+
+    uint32 end_msg = EXTERNAL_INDEX_END_MSG;
+    bytes_written = send(client_fd, &end_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
+
+    check_external_index_request_error(client_fd, bytes_written);
+}
+
+int create_external_index_session(const char                   *host,
+                                  int                           port,
+                                  const usearch_init_options_t *params,
+                                  const ldb_HnswBuildState     *buildstate,
+                                  uint32                        estimated_row_count)
+{
+    int                client_fd, status;
+    unsigned char      init_buf[ sizeof(external_index_params_t) + EXTERNAL_INDEX_MAGIC_MSG_SIZE ];
+    struct sockaddr_in serv_addr;
+    unsigned char      init_response[ EXTERNAL_INDEX_INIT_BUFFER_SIZE ] = {0};
+
+    if(!is_little_endian()) {
+        elog(ERROR, "external indexing is supported only for little endian byte ordering");
+    }
+    elog(INFO, "connecting to external indexing daemon on %s:%d", host, port);
+
+    if((client_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        elog(ERROR, "external index: socket creation failed");
+    }
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_port = htons(port);
+
+    if(inet_pton(AF_INET, host, &serv_addr.sin_addr) <= 0) {
+        elog(ERROR, "external index: invalid address");
+    }
+
+    set_write_timeout(client_fd, EXTERNAL_INDEX_SOCKET_TIMEOUT);
+    set_read_timeout(client_fd, EXTERNAL_INDEX_SOCKET_TIMEOUT);
+
+    // TODO:: connect timeout
+    if((status = connect(client_fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr))) < 0) {
+        elog(ERROR, "external index: connection with server failed");
+    }
+
+    external_index_params_t index_params = {
+        .pq = params->pq,
+        .metric_kind = params->metric_kind,
+        .quantization = params->quantization,
+        .dim = params->dimensions,
+        .m = params->connectivity,
+        .ef_construction = params->expansion_add,
+        .ef = params->expansion_search,
+        .num_centroids = params->num_centroids,
+        .num_subvectors = params->num_subvectors,
+        .estimated_capcity = estimated_row_count,
+    };
+
+    uint32 hdr_msg = EXTERNAL_INDEX_INIT_MSG;
+    memcpy(init_buf, &hdr_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE);
+    memcpy(init_buf + EXTERNAL_INDEX_MAGIC_MSG_SIZE, &index_params, sizeof(external_index_params_t));
+    uint32 bytes_written
+        = send(client_fd, init_buf, sizeof(external_index_params_t) + EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
+
+    check_external_index_request_error(client_fd, bytes_written);
+
+    if(params->pq) {
+        external_index_send_codebook(
+            client_fd, buildstate->pq_codebook, params->dimensions, params->num_centroids, params->num_subvectors);
+    }
+
+    uint32 buf_size = read(client_fd, &init_response, EXTERNAL_INDEX_INIT_BUFFER_SIZE);
+
+    check_external_index_response_error(client_fd, init_response, buf_size);
+
+    return client_fd;
+}
+
+void external_index_receive_index_file(uint32 external_client_fd, uint64 *num_added_vectors, char **result_buf)
+{
+    uint32        end_msg = EXTERNAL_INDEX_END_MSG;
+    unsigned char buffer[ sizeof(uint64_t) ];
+    int32         bytes_read, bytes_written;
+    uint64        index_size = 0, total_received = 0;
+
+    // disable read timeout while indexing is in progress
+    set_read_timeout(external_client_fd, 0);
+    // send message indicating that we have finished streaming tuples
+    bytes_written = send(external_client_fd, &end_msg, EXTERNAL_INDEX_MAGIC_MSG_SIZE, 0);
+    check_external_index_request_error(external_client_fd, bytes_written);
+
+    // read how many tuples have been indexed
+    bytes_read = read(external_client_fd, buffer, sizeof(uint64));
+    check_external_index_response_error(external_client_fd, buffer, bytes_read);
+    memcpy(num_added_vectors, buffer, sizeof(uint64));
+
+    // read index file size
+    bytes_read = read(external_client_fd, buffer, sizeof(uint64));
+    check_external_index_response_error(external_client_fd, buffer, bytes_read);
+    memcpy(&index_size, buffer, sizeof(uint64));
+
+    *result_buf = palloc0(index_size);
+
+    if(*result_buf == NULL) {
+        elog(ERROR, "external index: failed to allocate buffer for index file");
+    }
+
+    set_read_timeout(external_client_fd, EXTERNAL_INDEX_SOCKET_TIMEOUT);
+    // start reading index into buffer
+    while(total_received < index_size) {
+        bytes_read = read(external_client_fd, *result_buf + total_received, EXTERNAL_INDEX_FILE_BUFFER_SIZE);
+
+        // Using try/catch to close the socket on interrupt
+        PG_TRY();
+        {
+            // Check for CTRL-C interrupts
+            CHECK_FOR_INTERRUPTS();
+        }
+        PG_CATCH();
+        {
+            close(external_client_fd);
+            PG_RE_THROW();
+        }
+        PG_END_TRY();
+
+        check_external_index_response_error(
+            external_client_fd, (unsigned char *)*result_buf + total_received, bytes_read);
+
+        if(bytes_read == 0) {
+            break;
+        }
+
+        total_received += bytes_read;
+    }
+}
+
+void external_index_send_tuple(
+    uint32 external_client_fd, usearch_label_t *label, void *vector, uint8 scalar_bits, uint32 dimensions)
+{
+    unsigned char tuple[ EXTERNAL_INDEX_MAX_TUPLE_SIZE ];
+    uint32        tuple_size, bytes_written;
+    // send tuple over socket if this is external indexing
+    tuple_size = sizeof(usearch_label_t) + dimensions * (scalar_bits / 8);
+    memcpy(tuple, label, sizeof(usearch_label_t));
+    memcpy(tuple + sizeof(usearch_label_t), vector, tuple_size - sizeof(usearch_label_t));
+    bytes_written = send(external_client_fd, tuple, tuple_size, 0);
+    check_external_index_request_error(external_client_fd, bytes_written);
+}

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -285,8 +285,17 @@ void external_index_send_tuple(
 {
     unsigned char tuple[ EXTERNAL_INDEX_MAX_TUPLE_SIZE ];
     uint32        tuple_size, bytes_written;
+    uint32        vector_size;
+    uint32        dims = dimensions;
+
+    if(scalar_bits < CHAR_BIT) {
+        dims = dimensions * (sizeof(uint32) * CHAR_BIT);
+        vector_size = (dims + CHAR_BIT - 1) / CHAR_BIT;  // ceiling division
+        tuple_size = sizeof(usearch_label_t) + vector_size;
+    } else {
+        tuple_size = sizeof(usearch_label_t) + dimensions * (scalar_bits / CHAR_BIT);
+    }
     // send tuple over socket if this is external indexing
-    tuple_size = sizeof(usearch_label_t) + dimensions * (scalar_bits / 8);
     memcpy(tuple, label, sizeof(usearch_label_t));
     memcpy(tuple + sizeof(usearch_label_t), vector, tuple_size - sizeof(usearch_label_t));
     bytes_written = send(external_client_fd, tuple, tuple_size, 0);

--- a/src/hnsw/external_index_socket.h
+++ b/src/hnsw/external_index_socket.h
@@ -1,0 +1,47 @@
+#ifndef LDB_EXTERNAL_IDX_SOCKET_H
+#define LDB_EXTERNAL_IDX_SOCKET_H
+#include <postgres.h>
+
+#include <hnsw/build.h>
+
+#include "usearch.h"
+
+#define EXTERNAL_INDEX_MAGIC_MSG_SIZE   4
+#define EXTERNAL_INDEX_INIT_MSG         0x13333337
+#define EXTERNAL_INDEX_END_MSG          0x31333337
+#define EXTERNAL_INDEX_ERR_MSG          0x37333337
+#define EXTERNAL_INDEX_INIT_BUFFER_SIZE 1024
+#define EXTERNAL_INDEX_FILE_BUFFER_SIZE 1024 * 1024 * 10  // 10MB
+#define EXTERNAL_INDEX_SOCKET_TIMEOUT   10                // 10 seconds
+// maximum tuple size can be 8kb (8192 byte) + 8 byte label
+#define EXTERNAL_INDEX_MAX_TUPLE_SIZE 8200
+
+typedef struct external_index_params_t
+{
+    uint32                pq;
+    usearch_metric_kind_t metric_kind;
+    usearch_scalar_kind_t quantization;
+    uint32                dim;
+    uint32                m;
+    uint32                ef_construction;
+    uint32                ef;
+    uint32                num_centroids;
+    uint32                num_subvectors;
+    uint32                estimated_capcity;
+
+} external_index_params_t;
+
+void external_index_send_codebook(
+    uint32 client_fd, float *codebook, uint32 dimensions, uint32 num_centroids, uint32 num_subvectors);
+int  create_external_index_session(const char                   *host,
+                                   int                           port,
+                                   const usearch_init_options_t *params,
+                                   const ldb_HnswBuildState     *buildstate,
+                                   uint32                        estimated_row_count);
+void check_external_index_response_error(uint32 client_fd, unsigned char *buffer, int32 size);
+void external_index_receive_index_file(uint32 external_client_fd, uint64 *num_added_vectors, char **result_buf);
+void check_external_index_request_error(uint32 client_fd, int32 bytes_written);
+void external_index_send_tuple(
+    uint32 external_client_fd, usearch_label_t *label, void *vector, uint8 scalar_bits, uint32 dimensions);
+
+#endif  // LDB_EXTERNAL_IDX_SOCKET_H

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -53,6 +53,7 @@ typedef struct ldb_HnswOptions
     int   ef_construction;
     int   ef;
     bool  pq;
+    bool  external;
 
 #if PG_VERSION_NUM >= 130000
     QuantBitsEnum quant_bits;
@@ -68,14 +69,17 @@ int                   ldb_HnswGetEfConstruction(Relation index);
 int                   ldb_HnswGetEf(Relation index);
 char*                 ldb_HnswGetIndexFilePath(Relation index);
 bool                  ldb_HnswGetPq(Relation index);
+bool                  ldb_HnswGetExternal(Relation index);
 usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index);
 usearch_scalar_kind_t ldb_HnswGetScalarKind(Relation index);
 
 bytea* ldb_amoptions(Datum reloptions, bool validate);
 
-extern int  ldb_hnsw_init_k;
-extern int  ldb_hnsw_ef_search;
-extern bool ldb_is_test;
-extern bool ldb_pgvector_compat;
+extern int   ldb_hnsw_init_k;
+extern int   ldb_hnsw_ef_search;
+extern bool  ldb_is_test;
+extern bool  ldb_pgvector_compat;
+extern int   ldb_external_index_port;
+extern char* ldb_external_index_host;
 
 #endif  // LDB_HNSW_OPTIONS_H

--- a/test/expected/hnsw_create.out
+++ b/test/expected/hnsw_create.out
@@ -42,6 +42,26 @@ INFO:  validate_index() done, no issues found.
  
 (1 row)
 
+-- Validate that creating a hamming index works
+CREATE TABLE sift_base1k_int as SELECT id, v::INT[] FROM sift_base1k;
+CREATE INDEX ON sift_base1k_int USING lantern_hnsw (v dist_hamming_ops) WITH (M=8);
+INFO:  done init usearch index
+INFO:  inserted 1000 elements
+INFO:  done saving 1000 vectors
+SELECT * FROM ldb_get_indexes('sift_base1k_int');
+       indexname       |  size  |                                                  indexdef                                                  | indisvalid 
+-----------------------+--------+------------------------------------------------------------------------------------------------------------+------------
+ sift_base1k_int_v_idx | 680 kB | CREATE INDEX sift_base1k_int_v_idx ON sift_base1k_int USING lantern_hnsw (v dist_hamming_ops) WITH (m='8') | t
+(1 row)
+
+SELECT _lantern_internal.validate_index('sift_base1k_int_v_idx', false);
+INFO:  validate_index() start for sift_base1k_int_v_idx
+INFO:  validate_index() done, no issues found.
+ validate_index 
+----------------
+ 
+(1 row)
+
 -- Validate that index creation works with a larger number of vectors
 \ir utils/sift10k_array.sql
 CREATE TABLE IF NOT EXISTS sift_base10k (

--- a/test/sql/hnsw_create.sql
+++ b/test/sql/hnsw_create.sql
@@ -11,6 +11,12 @@ CREATE INDEX ON sift_base1k USING lantern_hnsw (v) WITH (dim=128, M=8);
 SELECT * FROM ldb_get_indexes('sift_base1k');
 SELECT _lantern_internal.validate_index('sift_base1k_v_idx', false);
 
+-- Validate that creating a hamming index works
+CREATE TABLE sift_base1k_int as SELECT id, v::INT[] FROM sift_base1k;
+CREATE INDEX ON sift_base1k_int USING lantern_hnsw (v dist_hamming_ops) WITH (M=8);
+SELECT * FROM ldb_get_indexes('sift_base1k_int');
+SELECT _lantern_internal.validate_index('sift_base1k_int_v_idx', false);
+
 -- Validate that index creation works with a larger number of vectors
 \ir utils/sift10k_array.sql
 SET lantern.pgvector_compat=FALSE;


### PR DESCRIPTION
add `external` param to index creation
add `lantern_hnsw.external_index_host` GUC.
add `lantern_hnsw.external_index_port` GUC.

When the `external` parameter will be passed we connect to remote lantern daemon  via tcp socket using the `external_index_host` and `external_index_port` GUC variables. First we send the index header to socket and codebook if needed. After getting ack response we start streaming tuples via socket to daemon which will create multithreaded usearch index. Then it will send back the `num_tuples_added` and `index_size` (which is the file size for index) and start streaming index file. We will collect index file into `result_buf` and use that to write the index into disk. For now we assume that the data sent will be in little endian byte ordering.

Corresponding PR in Lantern Extras [PR](https://github.com/lanterndata/lantern_extras/pull/142)

### TODO
- [x] add tests