### PR TITLE
close index file fd only if index is not build via socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 include(CheckSymbolExists)
 
-set(LANTERN_VERSION 0.3.2)
+set(LANTERN_VERSION 0.3.3)
 
 project(
   LanternDB
@@ -263,6 +263,7 @@ endif()
 set (_update_files
   sql/updates/0.3.0--0.3.1.sql
   sql/updates/0.3.1--0.3.2.sql
+  sql/updates/0.3.2--0.3.3.sql
 )
 
 # Generate version information for the binary

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -552,6 +552,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
 
     if(buildstate->index_file_path) {
         index_file_fd = open(buildstate->index_file_path, O_RDONLY);
+        assert(index_file_fd > 0);
     } else if(buildstate->external) {
         external_index_receive_index_file(buildstate->external_socket, &num_added_vectors, &result_buf);
     } else {
@@ -565,9 +566,8 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
         usearch_save(buildstate->usearch_index, tmp_index_file_path, &error);
         assert(error == NULL);
         index_file_fd = open(tmp_index_file_path, O_RDONLY);
+        assert(index_file_fd > 0);
     }
-
-    assert(index_file_fd > 0);
 
     if(!buildstate->external) {
         num_added_vectors = usearch_size(buildstate->usearch_index, &error);
@@ -598,9 +598,8 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
         munmap_ret = munmap(result_buf, index_file_stat.st_size);
         assert(munmap_ret == 0);
         LDB_UNUSED(munmap_ret);
+        close(index_file_fd);
     }
-
-    close(index_file_fd);
 
     if(buildstate->external) {
         buildstate->external_socket->close(buildstate->external_socket);


### PR DESCRIPTION
We were calling `close` syscall on `index_file_fd` variable for all cases when building the index,  but when building index with external socket no index file is used, so `index_file_fd` is not allocated. This led to undefined behaviour and led to crashes in some systems with errors like:
`error: could not seek to end of file "base/5/2610": Bad file descriptor` or
`PANIC:  could not write to log file 00000001000000000000004C at offset 13369344, length 8192: Bad file descriptor` 