### PR TITLE
change palloc to malloc for external indexing

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -602,6 +602,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
     }
 
     if(buildstate->external) {
+        free(result_buf);
         buildstate->external_socket->close(buildstate->external_socket);
     }
 

--- a/src/hnsw/external_index_socket.h
+++ b/src/hnsw/external_index_socket.h
@@ -16,6 +16,13 @@
 // maximum tuple size can be 8kb (8192 byte) + 8 byte label
 #define EXTERNAL_INDEX_MAX_TUPLE_SIZE 8200
 
+typedef enum
+{
+    EXTERNAL_INDEX_NO_ERR = 0,
+    EXTERNAL_INDEX_READ_FAILED,
+    EXTERNAL_INDEX_INDEXING_ERROR,
+} ExternalIndexResponseError;
+
 typedef struct external_index_params_t
 {
     uint32                pq;


### PR DESCRIPTION
Palloc has limit of 1GB ([source code reference](https://github.com/postgres/postgres/blob/1b373aed20e61e4a3033e1e396e4ba7c2a96bc20/src/include/utils/memutils.h#L40-L42)) , so for large indexes it was failing to allocate a necessary buffer to store the index.