### PR TITLE
Refactor `StoreExternalIndexNodes` function and receive index file from socket in chunks

### DIFF
--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -8,6 +8,21 @@
 #include "hnsw.h"
 #include "usearch.h"
 
+#define BUILD_INDEX_MAX_ERROR_SIZE 1024
+
+typedef enum
+{
+    BUILD_INDEX_OK = 0,
+    BUILD_INDEX_FAILED,
+    BUILD_INDEX_INTERRUPT,
+} BuildIndexStatusCode;
+
+typedef struct BuildIndexStatus
+{
+    BuildIndexStatusCode code;
+    char                 error[ BUILD_INDEX_MAX_ERROR_SIZE ];
+} BuildIndexStatus;
+
 typedef struct external_index_socket_t external_index_socket_t;
 
 typedef struct
@@ -23,6 +38,7 @@ typedef struct
     char                    *index_file_path;
     bool                     external;
     external_index_socket_t *external_socket;
+    BuildIndexStatus        *status;
 
     /* Statistics */
     double tuples_indexed;
@@ -43,5 +59,6 @@ void              ldb_ambuildunlogged(Relation index);
 int               GetHnswIndexDimensions(Relation index, IndexInfo *indexInfo);
 void              CheckHnswIndexDimensions(Relation index, Datum arrayDatum, int deimensions);
 void              ldb_reindex_external_index(Oid indrelid);
+void              CheckBuildIndexError(ldb_HnswBuildState *buildstate);
 // todo: does this render my check unnecessary
 #endif  // LDB_HNSW_BUILD_H

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -34,8 +34,11 @@ typedef struct
 
     /* Settings */
     int                      dimensions;
+    int                      index_file_fd;
+    uint64                   index_buffer_size;
     HnswColumnType           columnType;
     char                    *index_file_path;
+    char                    *index_buffer;
     bool                     external;
     external_index_socket_t *external_socket;
     BuildIndexStatus        *status;

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -8,7 +8,7 @@
 #include "hnsw.h"
 #include "usearch.h"
 
-#define BUILD_INDEX_MAX_ERROR_SIZE 1024
+#define BUILD_INDEX_MAX_ERROR_SIZE 1048
 
 typedef enum
 {

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -362,8 +362,13 @@ void StoreExternalIndex(Relation                 index,
 
             // rotate buffer
             buffer_position = EXTERNAL_INDEX_FILE_BUFFER_SIZE - local_progress;
-            assert(buffer_position <= BLCKSZ);
-            memcpy(external_index_data, external_index_data + local_progress, buffer_position);
+
+            if(total_bytes_read != index_file_size) {
+                assert(buffer_position <= BLCKSZ);
+                memcpy(external_index_data, external_index_data + local_progress, buffer_position);
+            } else {
+                pfree(external_index_data);
+            }
 
             progress += local_progress;
         }

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -9,6 +9,7 @@
 #include <storage/bufmgr.h>  // Buffer
 #include <utils/relcache.h>  // Relation
 
+#include "external_index_socket.h"
 #include "extra_dirtied.h"
 #include "fa_cache.h"
 #include "hnsw.h"
@@ -116,13 +117,16 @@ typedef struct
 
 void StoreExternalEmptyIndex(
     Relation index, ForkNumber forkNum, char *data, int dimensions, usearch_init_options_t *opts);
-void StoreExternalIndex(Relation                index,
-                        const metadata_t       *external_index_metadata,
-                        ForkNumber              forkNum,
-                        char                   *data,
-                        usearch_init_options_t *opts,
-                        uint32                  pg_dimension,
-                        size_t                  num_added_vectors);
+void StoreExternalIndex(Relation                 index,
+                        const metadata_t        *external_index_metadata,
+                        ForkNumber               forkNum,
+                        char                    *data,
+                        usearch_init_options_t  *opts,
+                        uint32                   pg_dimension,
+                        size_t                   num_added_vectors,
+                        external_index_socket_t *external_index_socket,
+                        uint64                   index_file_size,
+                        BuildIndexStatus        *status);
 
 // add the fully constructed index tuple to the index via wal
 // hdr is passed in so num_vectors, first_block_no, last_block_no can be updated

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -163,7 +163,8 @@ static void set_external_index_response_status(external_index_socket_t *socket_c
     buffer[ size - 1 ] = '\0';
 
     status->code = BUILD_INDEX_FAILED;
-    strncpy(status->error, buffer, BUILD_INDEX_MAX_ERROR_SIZE);
+    snprintf(
+        status->error, BUILD_INDEX_MAX_ERROR_SIZE, "external index error: %s", buffer + EXTERNAL_INDEX_MAGIC_MSG_SIZE);
 }
 
 static void set_external_index_request_status(external_index_socket_t *socket_con,

--- a/src/hnsw/external_index_socket.h
+++ b/src/hnsw/external_index_socket.h
@@ -62,15 +62,19 @@ external_index_socket_t *create_external_index_session(const char               
                                                        const usearch_init_options_t *params,
                                                        const ldb_HnswBuildState     *buildstate,
                                                        uint32                        estimated_row_count);
-void                     external_index_send_codebook(external_index_socket_t *socket_con,
-                                                      float                   *codebook,
-                                                      uint32                   dimensions,
-                                                      uint32                   num_centroids,
-                                                      uint32                   num_subvectors);
-void                     external_index_receive_index_file(external_index_socket_t *socket_con,
-                                                           uint64                  *num_added_vectors,
-                                                           char                   **result_buf);
-void                     external_index_send_tuple(
-                        external_index_socket_t *socket_con, usearch_label_t *label, void *vector, uint8 scalar_bits, uint32 dimensions);
+void                     external_index_receive_metadata(external_index_socket_t *socket_con,
+                                                         uint64                  *num_added_vectors,
+                                                         uint64                  *index_size,
+                                                         BuildIndexStatus        *status);
+uint64                   external_index_receive_index_part(external_index_socket_t *socket_con,
+                                                           char                    *result_buf,
+                                                           uint64                   size,
+                                                           BuildIndexStatus        *status);
+void                     external_index_send_tuple(external_index_socket_t *socket_con,
+                                                   usearch_label_t         *label,
+                                                   void                    *vector,
+                                                   uint8                    scalar_bits,
+                                                   uint32                   dimensions,
+                                                   BuildIndexStatus        *status);
 
 #endif  // LDB_EXTERNAL_IDX_SOCKET_H


### PR DESCRIPTION
Refactor StoreExternalIndexNodes function and receive index file from socket in chunks

- simplify `StoreExternalIndexNodes` function to write the provided buffer into index pages until fully flushed.
- try to write as much nodes as possible before requesting new chunk from external indexing server to optimize data streaming
- do not throw errors or process interrupts from `StoreExternalIndex` or external index socket functions, instead set status and error msg to `buildstat->status`, then check the status and throw the error or process interrupts after resource cleanup.
- receive and process index file in 10MB chunks