### PR TITLE
external index router

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build without SSL
         id: build_without_ssl
-        run: sudo sh -c "USE_SSL=0 PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT INSTALL_CLI=1 ./ci/scripts/build.sh"
+        run: sudo sh -c "USE_SSL=0 PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT INSTALL_CLI=1 ENABLE_FAILURE_POINTS=1 ./ci/scripts/build.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build
         id: build
-        run: sudo sh -c "USE_SSL=1 PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ENABLE_COVERAGE=$ENABLE_COVERAGE ./ci/scripts/build.sh"
+        run: sudo sh -c "USE_SSL=1 PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ENABLE_COVERAGE=$ENABLE_COVERAGE ENABLE_FAILURE_POINTS=1 ./ci/scripts/build.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 include(CheckSymbolExists)
 
-set(LANTERN_VERSION 0.3.3)
+set(LANTERN_VERSION 0.3.4)
 
 project(
   LanternDB
@@ -264,6 +264,7 @@ set (_update_files
   sql/updates/0.3.0--0.3.1.sql
   sql/updates/0.3.1--0.3.2.sql
   sql/updates/0.3.2--0.3.3.sql
+  sql/updates/0.3.3--0.3.4.sql
 )
 
 # Generate version information for the binary

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -80,6 +80,11 @@ function build_and_install() {
     flags="$flags -DCODECOVERAGE=ON"
     cp /usr/bin/gcov-12 /usr/bin/gcov
   fi
+  
+  if [[ "$ENABLE_FAILURE_POINTS" == "1" ]]
+  then
+    flags="$flags -DFAILURE_POINTS=ON"
+  fi
 
   # Run cmake
   cmake $flags ..

--- a/scripts/integration_tests.py
+++ b/scripts/integration_tests.py
@@ -960,23 +960,13 @@ def test_external_index_failures(external_index, primary, source_table, quant_bi
 
     try:
         primary.execute("testdb", f"""
-                        SELECT _lantern_internal.failure_point_enable('set_external_index_response_status', 'crash_on_response_size_check', 0);
+                        SELECT _lantern_internal.failure_point_enable('check_external_index_response_status', 'crash_on_response_size_check', 0);
                         SET lantern.external_index_secure={use_ssl};
                         CREATE INDEX {index_name} ON {table_name} USING lantern_hnsw (v {ops}) WITH (dim=128, M=10, quant_bits = {quant_bits}, external = true);
         """)
         assert False
     except Exception as e:
-        assert f"external index socket read failed" in str(e), f"Failed for set_external_index_response_status"
-
-    try:
-        primary.execute("testdb", f"""
-                        SELECT _lantern_internal.failure_point_enable('set_external_index_response_status', 'crash_on_response_size_check', 0);
-                        SET lantern.external_index_secure={use_ssl};
-                        CREATE INDEX {index_name} ON {table_name} USING lantern_hnsw (v {ops}) WITH (dim=128, M=10, quant_bits = {quant_bits}, external = true);
-        """)
-        assert False
-    except Exception as e:
-        assert f"external index socket read failed" in str(e), f"Failed for set_external_index_response_status"
+        assert f"external index socket read failed" in str(e), f"Failed for check_external_index_response_status"
 
     try:
         primary.execute("testdb", f"""

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -598,7 +598,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
             buildstate->external_socket, &num_added_vectors, &buildstate->index_buffer_size, buildstate->status);
         CheckBuildIndexError(buildstate);
 
-        uint32 bytes_read = external_index_receive_index_part(
+        uint32 bytes_read = external_index_receive_all(
             buildstate->external_socket, buildstate->index_buffer, USEARCH_HEADER_SIZE, buildstate->status);
         CheckBuildIndexError(buildstate);
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -41,10 +41,11 @@
 #include "bench.h"
 #include "external_index.h"
 #include "external_index_socket.h"
+#include "failure_point.h"
 #include "hnsw.h"
-#include "hnsw/pqtable.h"
-#include "hnsw/retriever.h"
 #include "options.h"
+#include "pqtable.h"
+#include "retriever.h"
 #include "utils.h"
 #include "vector.h"
 
@@ -602,7 +603,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
             buildstate->external_socket, buildstate->index_buffer, USEARCH_HEADER_SIZE, buildstate->status);
         CheckBuildIndexError(buildstate);
 
-        if(bytes_read != USEARCH_HEADER_SIZE) {
+        if(bytes_read != USEARCH_HEADER_SIZE || LDB_FAILURE_POINT_IS_ENABLED("crash_after_recv_header")) {
             buildstate->status->code = BUILD_INDEX_FAILED;
             strncpy(buildstate->status->error, "received invalid index header", BUILD_INDEX_MAX_ERROR_SIZE);
             CheckBuildIndexError(buildstate);

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -453,6 +453,7 @@ void CheckBuildIndexError(ldb_HnswBuildState *buildstate)
 
     if(buildstate->usearch_index) {
         usearch_free(buildstate->usearch_index, &error);
+        buildstate->usearch_index = NULL;
     }
 
     if(buildstate->external_socket) {

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -8,21 +8,6 @@
 #include "hnsw.h"
 #include "usearch.h"
 
-#define BUILD_INDEX_MAX_ERROR_SIZE 1048
-
-typedef enum
-{
-    BUILD_INDEX_OK = 0,
-    BUILD_INDEX_FAILED,
-    BUILD_INDEX_INTERRUPT,
-} BuildIndexStatusCode;
-
-typedef struct BuildIndexStatus
-{
-    BuildIndexStatusCode code;
-    char                 error[ BUILD_INDEX_MAX_ERROR_SIZE ];
-} BuildIndexStatus;
-
 typedef struct external_index_socket_t external_index_socket_t;
 
 typedef struct
@@ -41,7 +26,6 @@ typedef struct
     char                    *index_buffer;
     bool                     external;
     external_index_socket_t *external_socket;
-    BuildIndexStatus        *status;
 
     /* Statistics */
     double tuples_indexed;
@@ -62,6 +46,5 @@ void              ldb_ambuildunlogged(Relation index);
 int               GetHnswIndexDimensions(Relation index, IndexInfo *indexInfo);
 void              CheckHnswIndexDimensions(Relation index, Datum arrayDatum, int deimensions);
 void              ldb_reindex_external_index(Oid indrelid);
-void              CheckBuildIndexError(ldb_HnswBuildState *buildstate);
 // todo: does this render my check unnecessary
 #endif  // LDB_HNSW_BUILD_H

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -328,10 +328,10 @@ void StoreExternalIndex(Relation                 index,
         while(tuples_indexed < num_added_vectors) {
             local_progress = 0;
 
-            bytes_read = external_index_receive_index_part(external_index_socket,
-                                                           external_index_data + buffer_position,
-                                                           EXTERNAL_INDEX_FILE_BUFFER_SIZE - buffer_position,
-                                                           status);
+            bytes_read = external_index_receive_all(external_index_socket,
+                                                    external_index_data + buffer_position,
+                                                    EXTERNAL_INDEX_FILE_BUFFER_SIZE - buffer_position,
+                                                    status);
             total_bytes_read += bytes_read;
 
             if(status->code != BUILD_INDEX_OK) {

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -125,8 +125,7 @@ void StoreExternalIndex(Relation                 index,
                         uint32                   pg_dimension,
                         size_t                   num_added_vectors,
                         external_index_socket_t *external_index_socket,
-                        uint64                   index_file_size,
-                        BuildIndexStatus        *status);
+                        uint64                   index_file_size);
 
 // add the fully constructed index tuple to the index via wal
 // hdr is passed in so num_vectors, first_block_no, last_block_no can be updated

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -155,6 +155,10 @@ static void wait_for_data(external_index_socket_t *socket_con)
         CHECK_FOR_INTERRUPTS();
 
         if(activity < 0) {
+            // Sometimes the select syscall may be interrupted by signals
+            // If this signals are important they would be handled in CHECK_FOR_INTERRUPTS()
+            // If after calling CHECK_FOR_INTERRUPTS() we are still here we can ignore the signal
+            if(errno == EINTR) continue;
             snprintf((char *)&errstr, EXTERNAL_INDEX_MAX_ERR_SIZE, "%s", strerror(errno));
             elog(ERROR, "select syscall error: %s", errstr);
         }

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -202,7 +202,7 @@ static void set_external_index_response_status(external_index_socket_t *socket_c
     uint32 err_msg_size = 0;
     uint32 bytes_read = 0;
     uint32 total_bytes_read = 0;
-    char   recv_error[ BUILD_INDEX_MAX_ERROR_SIZE ];
+    char   recv_error[ 1024 ];
 
     if(size < 0 || LDB_FAILURE_POINT_IS_ENABLED("crash_on_response_size_check")) {
         status->code = BUILD_INDEX_FAILED;

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -605,8 +605,8 @@ void external_index_receive_metadata(external_index_socket_t *socket_con,
         return;
     }
 
-    // wait for data to be available
-    wait_for_data(socket_con, status);
+    // disable read timeout
+    set_read_timeout(socket_con->fd, 0, status);
     if(status->code != BUILD_INDEX_OK) {
         return;
     }

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -162,7 +162,7 @@ static void wait_for_data(external_index_socket_t *socket_con, BuildIndexStatus 
 
         if(activity < 0) {
             status->code = BUILD_INDEX_FAILED;
-            strncpy(status->error, "select syscall error", BUILD_INDEX_MAX_ERROR_SIZE);
+            snprintf(status->error, BUILD_INDEX_MAX_ERROR_SIZE, "select syscall error: %s", strerror(errno));
             return;
         }
 
@@ -502,7 +502,7 @@ external_index_socket_t *create_external_index_session(const char               
         memcpy(init_buf, &get_server_msg, sizeof(uint32));
         write_all(socket_con, init_buf, sizeof(uint32), 0, buildstate->status);
 
-        // wait for data to be available for read and also check for interrupts each 5s
+        // wait for data to be available for read and also check for interrupts each 1s
         wait_for_data(socket_con, buildstate->status);
 
         if(buildstate->status->code != BUILD_INDEX_OK) {

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -273,7 +273,7 @@ static void set_external_index_response_status(external_index_socket_t *socket_c
     }
 
     status->code = BUILD_INDEX_FAILED;
-    snprintf(status->error, BUILD_INDEX_MAX_ERROR_SIZE, "external index error: %s", (char *)&recv_error);
+    snprintf(status->error, BUILD_INDEX_MAX_ERROR_SIZE, "external index error: %.1024s", (char *)&recv_error);
 }
 
 static void set_external_index_request_status(external_index_socket_t *socket_con,

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -137,8 +137,6 @@ static void wait_for_data(external_index_socket_t *socket_con, BuildIndexStatus 
     struct timeval timeout;
     fd_set         read_fds;
 
-    int interval = 5;
-
     // Set the socket to non-blocking mode
     int flags = fcntl(socket_con->fd, F_GETFL, 0);
     if(flags == -1) {
@@ -157,7 +155,7 @@ static void wait_for_data(external_index_socket_t *socket_con, BuildIndexStatus 
         FD_ZERO(&read_fds);
         FD_SET(socket_con->fd, &read_fds);
 
-        timeout.tv_sec = 5;
+        timeout.tv_sec = 1;
         timeout.tv_usec = 0;
 
         int activity = select(socket_con->fd + 1, &read_fds, NULL, NULL, &timeout);

--- a/src/hnsw/external_index_socket.c
+++ b/src/hnsw/external_index_socket.c
@@ -136,12 +136,10 @@ static void wait_for_data(external_index_socket_t *socket_con)
     int flags = fcntl(socket_con->fd, F_GETFL, 0);
     if(flags == -1) {
         elog(ERROR, "error getting socket flags");
-        return;
     }
 
     if(fcntl(socket_con->fd, F_SETFL, flags | O_NONBLOCK) == -1) {
         elog(ERROR, "error setting socket to non-blocking mode");
-        return;
     }
 
     while(1) {
@@ -159,7 +157,6 @@ static void wait_for_data(external_index_socket_t *socket_con)
         if(activity < 0) {
             snprintf((char *)&errstr, EXTERNAL_INDEX_MAX_ERR_SIZE, "%s", strerror(errno));
             elog(ERROR, "select syscall error: %s", errstr);
-            return;
         }
 
         // If socket has data to read
@@ -244,7 +241,6 @@ static void check_external_index_response_status(external_index_socket_t *socket
 
         if(bytes_read < 0) {
             elog(ERROR, "external index socket read failed");
-            return;
         }
 
         total_bytes_read += bytes_read;

--- a/src/hnsw/external_index_socket.h
+++ b/src/hnsw/external_index_socket.h
@@ -6,15 +6,18 @@
 #include "external_index_socket_ssl.h"
 #include "usearch.h"
 
-#define EXTERNAL_INDEX_MAGIC_MSG_SIZE   4
-#define EXTERNAL_INDEX_INIT_MSG         0x13333337
-#define EXTERNAL_INDEX_END_MSG          0x31333337
-#define EXTERNAL_INDEX_ERR_MSG          0x37333337
-#define EXTERNAL_INDEX_INIT_BUFFER_SIZE 1024
-#define EXTERNAL_INDEX_FILE_BUFFER_SIZE 1024 * 1024 * 10  // 10MB
-#define EXTERNAL_INDEX_SOCKET_TIMEOUT   10                // 10 seconds
+#define EXTERNAL_INDEX_MAGIC_MSG_SIZE        4
+#define EXTERNAL_INDEX_INIT_MSG              0x13333337
+#define EXTERNAL_INDEX_END_MSG               0x31333337
+#define EXTERNAL_INDEX_ERR_MSG               0x37333337
+#define EXTERNAL_INDEX_INIT_BUFFER_SIZE      1024
+#define EXTERNAL_INDEX_FILE_BUFFER_SIZE      1024 * 1024 * 10  // 10MB
+#define EXTERNAL_INDEX_SOCKET_TIMEOUT        10                // 10 seconds
+#define EXTERNAL_INDEX_ROUTER_SOCKET_TIMEOUT 600               // 10 minutes
 // maximum tuple size can be 8kb (8192 byte) + 8 byte label
-#define EXTERNAL_INDEX_MAX_TUPLE_SIZE 8200
+#define EXTERNAL_INDEX_MAX_TUPLE_SIZE     8200
+#define EXTERNAL_INDEX_PROTOCOL_VERSION   1
+#define EXTERNAL_INDEX_ROUTER_SERVER_TYPE 0x2
 
 typedef struct external_index_params_t
 {
@@ -66,10 +69,10 @@ void                     external_index_receive_metadata(external_index_socket_t
                                                          uint64                  *num_added_vectors,
                                                          uint64                  *index_size,
                                                          BuildIndexStatus        *status);
-uint64                   external_index_receive_index_part(external_index_socket_t *socket_con,
-                                                           char                    *result_buf,
-                                                           uint64                   size,
-                                                           BuildIndexStatus        *status);
+uint64                   external_index_receive_all(external_index_socket_t *socket_con,
+                                                    char                    *result_buf,
+                                                    uint64                   size,
+                                                    BuildIndexStatus        *status);
 void                     external_index_send_tuple(external_index_socket_t *socket_con,
                                                    usearch_label_t         *label,
                                                    void                    *vector,

--- a/src/hnsw/external_index_socket.h
+++ b/src/hnsw/external_index_socket.h
@@ -10,6 +10,7 @@
 #define EXTERNAL_INDEX_INIT_MSG              0x13333337
 #define EXTERNAL_INDEX_END_MSG               0x31333337
 #define EXTERNAL_INDEX_ERR_MSG               0x37333337
+#define EXTERNAL_INDEX_MAX_ERR_SIZE          1024
 #define EXTERNAL_INDEX_INIT_BUFFER_SIZE      1024
 #define EXTERNAL_INDEX_FILE_BUFFER_SIZE      1024 * 1024 * 10  // 10MB
 #define EXTERNAL_INDEX_SOCKET_TIMEOUT        10                // 10 seconds
@@ -59,25 +60,17 @@ int64 write_ssl(external_index_socket_t *socket_con, const char *buf, uint32 siz
 void  close_ssl(external_index_socket_t *socket_con);
 /* ====================== */
 
-external_index_socket_t *create_external_index_session(const char                   *host,
-                                                       int                           port,
-                                                       bool                          secure,
-                                                       const usearch_init_options_t *params,
-                                                       const ldb_HnswBuildState     *buildstate,
-                                                       uint32                        estimated_row_count);
-void                     external_index_receive_metadata(external_index_socket_t *socket_con,
-                                                         uint64                  *num_added_vectors,
-                                                         uint64                  *index_size,
-                                                         BuildIndexStatus        *status);
-uint64                   external_index_receive_all(external_index_socket_t *socket_con,
-                                                    char                    *result_buf,
-                                                    uint64                   size,
-                                                    BuildIndexStatus        *status);
-void                     external_index_send_tuple(external_index_socket_t *socket_con,
-                                                   usearch_label_t         *label,
-                                                   void                    *vector,
-                                                   uint8                    scalar_bits,
-                                                   uint32                   dimensions,
-                                                   BuildIndexStatus        *status);
+void   create_external_index_session(const char                   *host,
+                                     int                           port,
+                                     bool                          secure,
+                                     const usearch_init_options_t *params,
+                                     const ldb_HnswBuildState     *buildstate,
+                                     uint32                        estimated_row_count);
+void   external_index_receive_metadata(external_index_socket_t *socket_con,
+                                       uint64                  *num_added_vectors,
+                                       uint64                  *index_size);
+uint64 external_index_read_all(external_index_socket_t *socket_con, char *result_buf, uint64 size);
+void   external_index_send_tuple(
+      external_index_socket_t *socket_con, usearch_label_t *label, void *vector, uint8 scalar_bits, uint32 dimensions);
 
 #endif  // LDB_EXTERNAL_IDX_SOCKET_H


### PR DESCRIPTION
- rename function `external_index_receive_index_part` to `external_index_receive_all`
- receive protocol version on the first message and compare with the one defined in client
- receive server type and check if it is router server receive new external indexing server address
- add function `wait_for_data` which will asynchronously check for data to be available for reading on socket. This will let us to handle interrupts while waiting for data
- now after error magic bytes, the length of the message will be returned and we will try to receive the error message from external indexing server