### PR TITLE
Replace linkedlist for takenbuffer with fixed array

### DIFF
--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -648,8 +648,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, unsigned long long id)
     ctx->takenbuffers[ ctx->takenbuffers_next ] = buf_p;
     ctx->takenbuffers_next = (ctx->takenbuffers_next + 1) % ctx->takenbuffers_size;
     return buf_p;
-#endif
-
+#else
     // if we locked the page, unlock it and only leave a pin on it.
     // otherwise, it must must have been locked because we are in the middle of an update and that node
     // was affected, so we must leave it locked
@@ -662,6 +661,7 @@ void *ldb_wal_index_node_retriever(void *ctxp, unsigned long long id)
         ctx->takenbuffers[ ctx->takenbuffers_next ] = buf;
         ctx->takenbuffers_next = (ctx->takenbuffers_next + 1) % ctx->takenbuffers_size;
     }
+#endif
 
 #if PG_VERSION_NUM >= 130000
     CheckMem(work_mem,

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -11,9 +11,7 @@
 
 #include "external_index_socket.h"
 #include "extra_dirtied.h"
-#include "fa_cache.h"
 #include "hnsw.h"
-#include "htab_cache.h"
 #include "options.h"
 #include "usearch.h"
 
@@ -83,8 +81,6 @@ typedef struct HnswIndexTuple
 
 typedef struct
 {
-    HTABCache block_numbers_cache;
-
     Relation index_rel;
 
     // used for inserts
@@ -92,20 +88,14 @@ typedef struct
 
     ExtraDirtiedBufs *extra_dirted;
 
-    FullyAssociativeCache fa_cache;
-
-    dlist_head takenbuffers;
-} RetrieverCtx;
-
-typedef struct
-{
 #if LANTERNDB_COPYNODES
-    char *buf;
+    char *takenbuffers;
 #else
-    Buffer buf;
+    Buffer *takenbuffers;
 #endif
-    dlist_node node;
-} BufferNode;
+    uint32 takenbuffers_size;
+    uint32 takenbuffers_next;
+} RetrieverCtx;
 
 typedef struct
 {

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -89,7 +89,7 @@ typedef struct
     ExtraDirtiedBufs *extra_dirted;
 
 #if LANTERNDB_COPYNODES
-    char *takenbuffers;
+    char **takenbuffers;
 #else
     Buffer *takenbuffers;
 #endif

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -127,7 +127,7 @@ bool ldb_aminsert(Relation         index,
         opts.quantization = usearch_scalar_b1_k;
         usearch_scalar = usearch_scalar_b1_k;
     }
-    opts.retriever_ctx = ldb_wal_retriever_area_init(index, hdr);
+    opts.retriever_ctx = ldb_wal_retriever_area_init(index, hdr, hdr->m);
     opts.retriever = ldb_wal_index_node_retriever;
     opts.retriever_mut = ldb_wal_index_node_retriever_mut;
 

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -17,7 +17,7 @@ RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPag
     ctx->index_rel = index_rel;
     ctx->header_page_under_wal = header_page_under_wal;
     ctx->extra_dirted = extra_dirtied_new();
-    ctx->takenbuffers_size = m * 2;
+    ctx->takenbuffers_size = m * 5;
     ctx->takenbuffers_next = 0;
 #if LANTERNDB_COPYNODES
     ctx->takenbuffers = palloc0(sizeof(char *) * ctx->takenbuffers_size);

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -5,66 +5,48 @@
 
 #include <assert.h>
 #include <common/relpath.h>
-#include <pg_config.h>  // BLCKSZ
+#include <storage/bufmgr.h>  // Buffer
 #include <utils/hsearch.h>
 #include <utils/relcache.h>
 
 #include "external_index.h"
-#include "htab_cache.h"
-#include "insert.h"
 
-RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPage *header_page_under_wal)
+RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPage *header_page_under_wal, uint32 m)
 {
     RetrieverCtx *ctx = palloc0(sizeof(RetrieverCtx));
     ctx->index_rel = index_rel;
     ctx->header_page_under_wal = header_page_under_wal;
     ctx->extra_dirted = extra_dirtied_new();
-
-    fa_cache_init(&ctx->fa_cache);
-
-    dlist_init(&ctx->takenbuffers);
-
-    /* fill in a buffer with blockno index information, before spilling it to disk */
-    ctx->block_numbers_cache = cache_create("BlockNumberCache");
+    ctx->takenbuffers_size = m * 2;
+    ctx->takenbuffers_next = 0;
+#if LANTERNDB_COPYNODES
+    ctx->takenbuffers = palloc0(sizeof(char *) * ctx->takenbuffers_size);
+#else
+    ctx->takenbuffers = palloc0(sizeof(Buffer) * ctx->takenbuffers_size);
+#endif
 
     return ctx;
 }
 
 void ldb_wal_retriever_area_reset(RetrieverCtx *ctx)
 {
-    dlist_mutable_iter miter;
-    dlist_foreach_modify(miter, &ctx->takenbuffers)
-    {
-        BufferNode *node = dlist_container(BufferNode, node, miter.cur);
-        if(node->buf != InvalidBuffer) {
-            ReleaseBuffer(node->buf);
+    for(uint32 i = 0; i < ctx->takenbuffers_size; i++) {
+        if(ctx->takenbuffers[ i ]) {
+#if LANTERNDB_COPYNODES
+            pfree(ctx->takenbuffers[ i ]);
+            ctx->takenbuffers[ i ] = NULL;
+#else
+            ReleaseBuffer(ctx->takenbuffers[ i ]);
+            ctx->takenbuffers[ i ] = 0;
+#endif
         }
-        dlist_delete(miter.cur);
-        pfree(node);
     }
-    dlist_init(&ctx->takenbuffers);
-
-    fa_cache_init(&ctx->fa_cache);
+    ctx->takenbuffers_next = 0;
 }
 
 void ldb_wal_retriever_area_fini(RetrieverCtx *ctx)
 {
-    cache_destroy(&ctx->block_numbers_cache);
-    dlist_mutable_iter miter;
-    dlist_foreach_modify(miter, &ctx->takenbuffers)
-    {
-        BufferNode *node = dlist_container(BufferNode, node, miter.cur);
-#if LANTERNDB_COPYNODES
-        pfree(node->buf);
-#else
-        if(node->buf != InvalidBuffer) {
-            ReleaseBuffer(node->buf);
-        }
-#endif
-        dlist_delete(miter.cur);
-        pfree(node);
-    }
-    dlist_init(&ctx->takenbuffers);
-
+    ldb_wal_retriever_area_reset(ctx);
+    pfree(ctx->takenbuffers);
     extra_dirtied_free(ctx->extra_dirted);
 }

--- a/src/hnsw/retriever.h
+++ b/src/hnsw/retriever.h
@@ -9,7 +9,7 @@
 
 // this area is used to return pointers back to usearch
 
-RetrieverCtx* ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPage* header_page_under_wal);
+RetrieverCtx* ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPage* header_page_under_wal, uint32 m);
 // can be used after each usearch_search to tell the retriever that the pointers given out
 // will no longer be used
 void ldb_wal_retriever_area_reset(RetrieverCtx* ctx);

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -28,10 +28,9 @@ IndexScanDesc ldb_ambeginscan(Relation index, int nkeys, int norderbys)
     int                    dimensions;
     usearch_error_t        error = NULL;
     usearch_init_options_t opts;
+    RetrieverCtx          *retriever_ctx;
 
     (void)CheckExtensionVersions();
-
-    RetrieverCtx *retriever_ctx = ldb_wal_retriever_area_init(index, NULL);
 
     scan = RelationGetIndexScan(index, nkeys, norderbys);
 
@@ -52,6 +51,7 @@ IndexScanDesc ldb_ambeginscan(Relation index, int nkeys, int norderbys)
     headerp = (HnswIndexHeaderPage *)PageGetContents(page);
     assert(headerp->magicNumber == LDB_WAL_MAGIC_NUMBER);
 
+    retriever_ctx = ldb_wal_retriever_area_init(index, NULL, headerp->m);
     // Initialize usearch index options based on params stored in our index header
     dimensions = headerp->vector_dim;
 
@@ -279,6 +279,7 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
                                          scanstate->labels,
                                          scanstate->distances,
                                          &error);
+
         ldb_wal_retriever_area_reset(scanstate->retriever_ctx);
 
         scanstate->count = num_returned;


### PR DESCRIPTION
- Replace `takenbuffers` linked list with fixed size (m*2) array and release unused buffers when pinning new ones after the array is filled.
- Remove unused htab and fa_cache instances in retriever context
- Only lock buffers when getting nodes if `LANTERNDB_COPYNODES` is enabled

TODO
- fix `LANTERNDB_COPYNODES` path, currently tests are failing with incorrect scan results