### PR TITLE
Narek/update deps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubicloud-standard-4-arm, macos-13]
-        postgres: [11, 12, 13, 14, 15, 16]
+        postgres: [12, 13, 14, 15, 16]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubicloud-standard-4-arm, macos-13]
-        postgres: [11, 12, 13, 14, 15, 16]
+        postgres: [12, 13, 14, 15, 16]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -29,7 +29,6 @@ jobs:
           - postgres: 14
           - postgres: 13
           - postgres: 12
-          - postgres: 11
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        pg: ["11.21", "12.16", "13.12", "14.9", "15.4", "16.0"]
+        pg: ["12.16", "13.12", "14.9", "15.4", "16.0"]
     steps:
     - name: Enable UBSan if this is a release
       if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubicloud-standard-4-arm, macos-13]
-        postgres: [11, 12, 13, 14, 15, 16]
+        postgres: [12, 13, 14, 15, 16]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -119,8 +119,7 @@ jobs:
         run: ./ci/scripts/run-tests-mac.sh
         env:
           PG_VERSION: ${{ matrix.postgres }}
-        # postgresql@11 seems broken on brew on Ventura used in the runner https://github.com/orgs/Homebrew/discussions/5263
-        if: ${{ startsWith(matrix.os, 'mac') && matrix.postgres != 11 }}
+        if: ${{ startsWith(matrix.os, 'mac') }}
       - name: Run integration tests mac
         id: integration-test-mac
         run: |
@@ -128,7 +127,7 @@ jobs:
           echo "Done with integration tests"
         env:
           PG_VERSION: ${{ matrix.postgres }}
-        if: ${{ startsWith(matrix.os, 'mac') && matrix.postgres != 11 }}
+        if: ${{ startsWith(matrix.os, 'mac') }}
       - name: Upload Postgres logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -176,7 +176,7 @@ jobs:
           PG_VERSION: ${{ matrix.postgres }}
       - name: Install extension
         run: |
-          cargo install cargo-pgrx --version 0.11.3
+          cargo install cargo-pgrx --version 0.12.7
           cargo pgrx init "--pg$PG_VERSION" /usr/bin/pg_config
           RUSTFLAGS="--cfg profile=\"ci-build\"" cargo pgrx install --sudo --pg-config /usr/bin/pg_config --package lantern_extras
         env:

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -20,7 +20,7 @@ function setup_cargo_deps() {
   	mkdir .cargo
   fi
   echo "[target.$(rustc -vV | sed -n 's|host: ||p')]" >> .cargo/config
-  cargo install cargo-pgrx --version 0.11.3
+  cargo install cargo-pgrx --version 0.12.7
   cargo pgrx init "--pg$PG_VERSION" /usr/bin/pg_config
 }
 

--- a/ci/scripts/build-mac.sh
+++ b/ci/scripts/build-mac.sh
@@ -18,7 +18,7 @@ function setup_cargo_deps() {
   echo "[target.$(rustc -vV | sed -n 's|host: ||p')]" > .cargo/config
   echo 'rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]' >> .cargo/config
 
-  cargo install cargo-pgrx --version 0.11.3
+  cargo install cargo-pgrx --version 0.12.7
   cargo pgrx init "--pg$PG_VERSION" $(which pg_config)
 }
 

--- a/ci/scripts/utils.sh
+++ b/ci/scripts/utils.sh
@@ -16,7 +16,7 @@ function setup_rust() {
   if [ ! -f /tmp/rustup.sh ]; then
     curl -k -o /tmp/rustup.sh https://sh.rustup.rs
     chmod +x /tmp/rustup.sh
-    /tmp/rustup.sh -y --default-toolchain=1.78.0
+    /tmp/rustup.sh -y --default-toolchain=1.82.0
   fi
   . "$HOME/.cargo/env"
 }

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM rust:1.78.0 as build
+FROM rust:1.82.0 as build
 # Copy the files in your machine to the Docker image
 WORKDIR /app
 COPY lantern_cli .

--- a/docker/Dockerfile.cli.cuda
+++ b/docker/Dockerfile.cli.cuda
@@ -1,4 +1,4 @@
-FROM rust:1.78.0 as build
+FROM rust:1.82.0 as build
 # Copy the files in your machine to the Docker image
 WORKDIR /app
 COPY lantern_cli .

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -20,7 +20,7 @@ ndarray = { version = "0.15.6", features = ["rayon"] }
 rayon = { version="1.10.0", optional = true }
 md5 = {version="0.7.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-gcp_auth = {version="0.10.0", optional = true}
+gcp_auth = {version="0.12.3", optional = true}
 serde_json = "1.0.132"
 tokio-postgres = { version="0.7.12", optional = true }
 futures = "0.3.31"

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.41.0", features = ["full"] }
 lazy_static = "1.5.0"
 itertools = "0.13.0"
 csv = "1.3.0"
-sysinfo = "0.29.11"
+sysinfo = "0.32.0"
 tiktoken-rs = "0.6.0"
 url = "2.5"
 num_cpus = "1.16.0"

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.5.0"
 itertools = "0.13.0"
 csv = "1.3.0"
 sysinfo = "0.29.11"
-tiktoken-rs = "0.5.8"
+tiktoken-rs = "0.6.0"
 url = "2.5"
 num_cpus = "1.16.0"
 ort = { version = "1.16.3", features = ["load-dynamic", "cuda", "openvino"] }

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -10,50 +10,50 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.0", features = ["derive"] }
-anyhow = "1.0.75"
-postgres = "0.19.7"
+clap = { version = "4.5.20", features = ["derive"] }
+anyhow = "1.0.91"
+postgres = "0.19.9"
 rand = "0.8.5"
 linfa-clustering = { version = "0.7.0", features = ["ndarray-linalg"], optional = true }
 linfa = {version = "0.7.0", optional = true}
 ndarray = { version = "0.15.6", features = ["rayon"] }
-rayon = { version="1.8.1", optional = true }
+rayon = { version="1.10.0", optional = true }
 md5 = {version="0.7.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.111"
 gcp_auth = {version="0.10.0", optional = true}
-tokio-postgres = { version="0.7.10", optional = true }
-futures = "0.3.28"
-tokio = { version = "1.33.0", features = ["full"] }
-lazy_static = "1.4.0"
-itertools = "0.11.0"
+serde_json = "1.0.132"
+tokio-postgres = { version="0.7.12", optional = true }
+futures = "0.3.31"
+tokio = { version = "1.41.0", features = ["full"] }
+lazy_static = "1.5.0"
+itertools = "0.13.0"
 csv = "1.3.0"
-url = "2.2"
-num_cpus = "1.15.0"
-ort = { version = "1.16.0", features = ["load-dynamic", "cuda", "openvino"] }
-tokenizers = { version = "0.15.2", features = ["default"] }
-image = { version = "0.24.9", features = ["jpeg", "png", "webp" ]}
 sysinfo = "0.29.11"
-nvml-wrapper = "0.9.0"
-strum = { version = "0.25", features = ["derive"] }
 tiktoken-rs = "0.5.8"
-regex = "1.10.3"
-postgres-types = { version = "0.2.6", features = ["derive"] }
+url = "2.5"
+num_cpus = "1.16.0"
+ort = { version = "1.16.3", features = ["load-dynamic", "cuda", "openvino"] }
+tokenizers = { version = "0.20.1", features = ["default"] }
+image = { version = "0.25.4", features = ["jpeg", "png", "webp" ]}
+nvml-wrapper = "0.10.0"
+strum = { version = "0.26", features = ["derive"] }
+regex = "1.11.1"
+postgres-types = { version = "0.2.8", features = ["derive"] }
 usearch = { git = "https://github.com/Ngalstyan4/usearch.git", rev = "aa4f91d21230fd611b6c7741fa06be8c20acc9a9" }
-actix-web = { version = "4.5.1", optional = true }
-env_logger = { version = "0.11.2", optional = true }
-deadpool-postgres = { version = "0.12.1", optional = true }
-deadpool = { version = "0.10.0", optional = true}
-bytes = { version = "1.5.0", optional = true}
-utoipa = { version = "4.2.0", optional = true}
-utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"], optional = true }
-actix-web-httpauth = { version = "0.8.1", optional = true }
-tokio-util = "0.7.11"
+actix-web = { version = "4.9.0", optional = true }
+env_logger = { version = "0.11.5", optional = true }
+deadpool-postgres = { version = "0.14.0", optional = true }
+deadpool = { version = "0.12.1", optional = true}
+bytes = { version = "1.8.0", optional = true}
+utoipa = { version = "5.1.3", optional = true}
+utoipa-swagger-ui = { version = "8.0.3", features = ["actix-web"], optional = true }
+actix-web-httpauth = { version = "0.8.2", optional = true }
+tokio-util = "0.7.12"
 bitvec = { version="1.0.1", optional=true }
-rustls = { version="0.23.12", optional=true }
-rustls-pemfile = { version="2.1.2", optional=true }
+rustls = { version="0.23.16", optional=true }
+rustls-pemfile = { version="2.2.0", optional=true }
 glob = { version="0.3.1", optional=true }
-reqwest = { version = "0.12.8", default-features = false, features = ["json", "blocking", "rustls-tls"] }
+reqwest = { version = "0.12.9", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 
 [features]
 default = ["cli", "daemon", "http-server", "autotune", "pq", "external-index", "external-index-server", "embeddings"]

--- a/lantern_cli/src/embeddings/core/openai_runtime.rs
+++ b/lantern_cli/src/embeddings/core/openai_runtime.rs
@@ -283,9 +283,9 @@ impl<'a> OpenAiRuntime<'a> {
 
     fn group_vectors_by_token_count(
         &self,
-        input: Vec<Vec<usize>>,
+        input: Vec<Vec<u32>>,
         max_token_count: usize,
-    ) -> Vec<Vec<Vec<usize>>> {
+    ) -> Vec<Vec<Vec<u32>>> {
         let mut result = Vec::new();
         let mut current_group = Vec::new();
         let mut current_group_token_count = 0;
@@ -333,7 +333,7 @@ impl<'a> OpenAiRuntime<'a> {
 
         let model_map = MODEL_INFO_MAP.read().await;
         let model_info = check_and_get_model!(model_map, model_name);
-        let token_groups: Vec<Vec<usize>> = inputs
+        let token_groups: Vec<Vec<u32>> = inputs
             .iter()
             .map(|input| {
                 let mut tokens = model_info.tokenizer.encode_with_special_tokens(input);

--- a/lantern_cli/src/embeddings/core/ort_runtime.rs
+++ b/lantern_cli/src/embeddings/core/ort_runtime.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use image::{imageops::FilterType, io::Reader as ImageReader, GenericImageView};
+use image::{imageops::FilterType, GenericImageView, ImageReader};
 use itertools::Itertools;
 use ndarray::{s, Array2, Array4, ArrayBase, Axis, CowArray, CowRepr, Dim, IxDynImpl};
 use ort::session::Session;

--- a/lantern_cli/src/embeddings/core/ort_runtime.rs
+++ b/lantern_cli/src/embeddings/core/ort_runtime.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use sysinfo::{System, SystemExt};
+use sysinfo::System;
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 use tokio::{fs, sync::Mutex};
 use url::Url;

--- a/lantern_cli/src/embeddings/core/utils.rs
+++ b/lantern_cli/src/embeddings/core/utils.rs
@@ -5,7 +5,7 @@ use reqwest::redirect::Policy;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fs::create_dir_all, io::Cursor, time::Duration};
-use sysinfo::{System, SystemExt};
+use sysinfo::System;
 
 type GetResponseFn<T> = Box<dyn Fn(Vec<u8>) -> Result<T, anyhow::Error> + Send + Sync>;
 

--- a/lantern_cli/src/http_server/pq.rs
+++ b/lantern_cli/src/http_server/pq.rs
@@ -32,7 +32,7 @@ pub struct CreatePQInput {
     post,
     path = "/collections/{name}/pq",
     request_body  (
-        content = CreateIndexInput,
+        content = CreatePQInput,
         example = json!(r#"{ "column": "vector", "clusters": 2, "splits": 1 }"#),
     ),
     responses(

--- a/lantern_cli/src/pq/gcp_batch.rs
+++ b/lantern_cli/src/pq/gcp_batch.rs
@@ -136,9 +136,9 @@ struct BatchJobResponse {
 fn run_batch_job(logger: &Logger, task_body: &str, parent: &str) -> AnyhowVoidResult {
     let url = format!("https://batch.googleapis.com/v1/{parent}/jobs");
     let runtime = Runtime::new()?;
-    let authentication_manager = runtime.block_on(gcp_auth::AuthenticationManager::new())?;
+    let authentication_manager = runtime.block_on(gcp_auth::provider())?;
     let token = runtime.block_on(
-        authentication_manager.get_token(&["https://www.googleapis.com/auth/cloud-platform"]),
+        authentication_manager.token(&["https://www.googleapis.com/auth/cloud-platform"]),
     )?;
     let token_str = token.as_str();
 
@@ -178,7 +178,7 @@ fn run_batch_job(logger: &Logger, task_body: &str, parent: &str) -> AnyhowVoidRe
     logger.info(&format!("Job {} created. Waiting to succeed", job_name));
     loop {
         let token = runtime.block_on(
-            authentication_manager.get_token(&["https://www.googleapis.com/auth/cloud-platform"]),
+            authentication_manager.token(&["https://www.googleapis.com/auth/cloud-platform"]),
         )?;
         let token_str = token.as_str();
 

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.4.1"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 doctest = false
 
 [features]
 default = ["pg15"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
-pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
-pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
-pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.11.3"
+pgrx = "=0.12.7"
 flate2 = "1.0"
 ftp = "3"
 tar = "0.4"
@@ -37,5 +37,8 @@ tokio-util = "0.7.12"
 tokio = { version = "1.41.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-pgrx-tests = "=0.11.3"
+pgrx-tests = "=0.12.7"
 
+[[bin]]
+name = "pgrx_embed_lantern_extras"
+path = "./src/bin/pgrx_embed.rs"

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 
 [features]
 default = ["pg15"]
-pg11 = ["pgrx/pg11", "pgrx-tests/pg11" ]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -22,15 +22,20 @@ pgrx = "=0.11.3"
 flate2 = "1.0"
 ftp = "3"
 tar = "0.4"
-itertools = "0.11"
+itertools = "0.13"
 backtrace = "0.3"
-url = "2.2"
-lantern_cli = { path = "../lantern_cli", default-features = false, features=["external-index", "embeddings", "autotune", "daemon"] }
-anyhow = "1.0.75"
+url = "2.5"
+lantern_cli = { path = "../lantern_cli", default-features = false, features = [
+  "external-index",
+  "embeddings",
+  "autotune",
+  "daemon",
+] }
+anyhow = "1.0.91"
 rand = "0.8.5"
-serde_json = "1.0.111"
-tokio-util = "0.7.11"
-tokio = { version = "1.33.0", features = ["rt-multi-thread"] }
+serde_json = "1.0.132"
+tokio-util = "0.7.12"
+tokio = { version = "1.41.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 pgrx-tests = "=0.11.3"

--- a/lantern_extras/README.md
+++ b/lantern_extras/README.md
@@ -91,7 +91,7 @@ sudo apt install pkg-config libssl-dev zlib1g-dev libreadline-dev
 sudo apt-get install clang
 
 #install pgrx itself
-cargo install --locked cargo-pgrx --version 0.11.3
+cargo install --locked cargo-pgrx --version 0.12.7
 cargo pgrx init --pg15 $(which pg_config)
 ```
 

--- a/lantern_extras/src/bin/pgrx_embed.rs
+++ b/lantern_extras/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();


### PR DESCRIPTION
This updates (almost) all rust dependencies of the project

Dependencies left out of date:
1. gcp_auth - An authentication API changed, did not upgrade since I did not know the new API and the right way to test
2. ndarray - upgrading causes some cryptic error messages

Notes on pgrx upgrade:

- The added `[[bin]]` section and the `pgrx_embed.rs` file were required by `pgrx 0.12.*`. Those would be autogenerated if we created a pgrx project with the new version.
- I dropped `pg11` but have not added `pg17` yet. Let's do that separately. I just needed pgrx 0.12.* for other changes.