### PR TITLE
Fix typo in comments: 'enought' to 'enough'

### DIFF
--- a/lantern_hnsw/src/hnsw/scan.c
+++ b/lantern_hnsw/src/hnsw/scan.c
@@ -308,7 +308,7 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
 #endif
 
         // todo:: there is a mid-sized designed issue with index storage
-        // labels must be large enought to store relblockno+ indexblockno
+        // labels must be large enough to store relblockno+ indexblockno
         // currently they only store relblockno
         // the second is needed so we can hold a pin in here on the index page
         // the good news is that this is not an issue until we support deletions


### PR DESCRIPTION
This commit corrects a minor typo in the comments within lantern_hnsw/src/hnsw/scan.c on line 311, where "enought" has been changed to "enough." This change improves code readability and aligns the documentation with standard spelling.

- Related issue: #353 