### PR TITLE
Make sure invalid reloptions are silently ignored when the caller req…

### DIFF
--- a/lantern_hnsw/src/hnsw/options.c
+++ b/lantern_hnsw/src/hnsw/options.c
@@ -179,9 +179,8 @@ bytea *ldb_amoptions(Datum reloptions, bool validate)
     };
 
 #if PG_VERSION_NUM >= 130000
-    LDB_UNUSED(validate);
     return (bytea *)build_reloptions(
-        reloptions, true, ldb_hnsw_index_withopts, sizeof(ldb_HnswOptions), tab, lengthof(tab));
+        reloptions, validate, ldb_hnsw_index_withopts, sizeof(ldb_HnswOptions), tab, lengthof(tab));
 #else
     // clang-format off
     relopt_value *options;


### PR DESCRIPTION
…uests that

Per docs: https://www.postgresql.org/docs/current/index-functions.html

> validate is false when loading options already stored in pg_catalog;
an invalid entry could only be found if the access method has changed its rules for options, and in that case ignoring obsolete entries is appropriate.