### PR TITLE
do not use external indexing if table does not contain tuples

### DIFF
--- a/lantern_hnsw/src/hnsw/build.c
+++ b/lantern_hnsw/src/hnsw/build.c
@@ -520,6 +520,10 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
 
     uint32_t estimated_row_count = EstimateRowCount(heap);
 
+    if(estimated_row_count < EXTERNAL_INDEX_MIN_TUPLES) {
+        buildstate->external = false;
+    }
+
     if(buildstate->external) {
         buildstate->external_socket = palloc0(sizeof(external_index_socket_t));
         create_external_index_session(ldb_external_index_host,

--- a/lantern_hnsw/src/hnsw/external_index_socket.h
+++ b/lantern_hnsw/src/hnsw/external_index_socket.h
@@ -6,6 +6,7 @@
 #include "external_index_socket_ssl.h"
 #include "usearch.h"
 
+#define EXTERNAL_INDEX_MIN_TUPLES            1
 #define EXTERNAL_INDEX_MAGIC_MSG_SIZE        4
 #define EXTERNAL_INDEX_INIT_MSG              0x13333337
 #define EXTERNAL_INDEX_END_MSG               0x31333337

--- a/lantern_hnsw/test/expected/hnsw_create.out
+++ b/lantern_hnsw/test/expected/hnsw_create.out
@@ -162,3 +162,11 @@ CREATE INDEX ON small_world4 USING lantern_hnsw (vector) WITH (M=14, ef=22, ef_c
 INFO:  done init usearch index
 ERROR:  Wrong number of dimensions: 3 instead of 4 expected
 \set ON_ERROR_STOP on
+\set ON_ERROR_STOP off
+SET lantern.external_index_port=65535; -- this should fail if it will try to connect
+CREATE TABLE empty(v REAL[]);
+CREATE INDEX ON empty USING lantern_hnsw (v) WITH (dim=3, external=true); -- should success
+INFO:  done init usearch index
+INFO:  inserted 0 elements
+INFO:  done saving 0 vectors
+\set ON_ERROR_STOP on

--- a/lantern_hnsw/test/sql/hnsw_create.sql
+++ b/lantern_hnsw/test/sql/hnsw_create.sql
@@ -83,3 +83,9 @@ UPDATE small_world4 SET vector = '{0,0,0}' WHERE id = '001';
 \set ON_ERROR_STOP off
 CREATE INDEX ON small_world4 USING lantern_hnsw (vector) WITH (M=14, ef=22, ef_construction=2);
 \set ON_ERROR_STOP on
+
+\set ON_ERROR_STOP off
+SET lantern.external_index_port=65535; -- this should fail if it will try to connect
+CREATE TABLE empty(v REAL[]);
+CREATE INDEX ON empty USING lantern_hnsw (v) WITH (dim=3, external=true); -- should success
+\set ON_ERROR_STOP on


### PR DESCRIPTION
This solves the issue when it tries to connect to external indexing server for external indexes on `pg_restore` during pg_upgrade as it first creates all indexes in catalog using index definitions and then imports the underlying data.