### PR TITLE
Make lantern_extras prefix reserved in pgrx

### DIFF
--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -148,6 +148,11 @@ pub unsafe extern "C" fn _PG_init() {
         GucContext::Userset,
         GucFlags::NO_SHOW_ALL,
     );
+    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+    unsafe {
+        use pg_sys::AsPgCStr;
+        pg_sys::MarkGUCPrefixReserved("lantern_extras".as_pg_cstr());
+    }
 }
 
 #[pg_guard]
@@ -243,5 +248,26 @@ pub mod pg_test {
             "lantern_extras.daemon_databases='pgrx_tests'",
             "lantern_extras.enable_daemon=true",
         ]
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+pub mod tests {
+
+    // note: this will not get to unwrap, since the failure in the result only represents
+    // failures in the SPI machinery.
+    // Postgres aborts the transaction and returns an error message to the client when the SPI
+    // query fails. So, the rust interface has no Error representation for a failed query.
+    // As a last resort we can ensure the test panics with the expected message.
+    // https://www.postgresql.org/docs/current/spi.html
+
+    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+    #[pgrx::pg_test]
+    #[should_panic(expected = "invalid configuration parameter name")]
+    fn lantern_extras_prefix_reserved() {
+        use pgrx::{error, Spi};
+        Spi::run("SET lantern_extras.aldkjalsdkj_invalid_param = 42").unwrap();
+        error!("Managed to update a reserved-prefix variable. This should never be reached");
     }
 }


### PR DESCRIPTION
Make sure MarkGUCPrefix is only used in pg15 and pg16