### PR TITLE
fix(lantern_hnsw/build.c): index size exceeded build warning.

### DIFF
--- a/lantern_hnsw/src/hnsw/build.c
+++ b/lantern_hnsw/src/hnsw/build.c
@@ -537,7 +537,7 @@ static void BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo, ldb_
                  index,
                  buildstate->usearch_index,
                  estimated_row_count,
-                 "index size exceeded maintenance_work_mem during index construction, consider increasing"
+                 "index size exceeded maintenance_work_mem during index construction, consider increasing "
                  "maintenance_work_mem");
 
         usearch_reserve(buildstate->usearch_index, estimated_row_count, &error);


### PR DESCRIPTION
For now the warning is:
`WARNING:  index size exceeded maintenance_work_mem during index construction, consider increasingmaintenance_work_mem`

Fix it to
`WARNING:  index size exceeded maintenance_work_mem during index construction, consider increasing maintenance_work_mem`